### PR TITLE
Enable cifti parsing in python3

### DIFF
--- a/nibabel/cifti/cifti.py
+++ b/nibabel/cifti/cifti.py
@@ -18,6 +18,7 @@ Stuff about the CIFTI file format here:
 
 '''
 from __future__ import division, print_function, absolute_import
+from ..externals.six import string_types
 
 import numpy as np
 
@@ -81,7 +82,7 @@ class CiftiMetaData(object):
     def _add_remove_metadata(self, metadata, func):
         pairs = []
         if isinstance(metadata, (list, tuple)):
-            if isinstance(metadata[0], basestring):
+            if isinstance(metadata[0], string_types):
                 if len(metadata) != 2:
                     raise ValueError('nvpair must be a 2-list or 2-tuple')
                 pairs = [tuple((metadata[0], metadata[1]))]
@@ -806,7 +807,7 @@ class CiftiImage(object):
         from ..nifti1 import Nifti1Extension
         data = np.reshape(self.data, [1, 1, 1, 1] + list(self.data.shape))
         header = self.extra
-        extension = Nifti1Extension(32, self.header.to_xml())
+        extension = Nifti1Extension(32, self.header.to_xml().encode())
         header.extensions.append(extension)
         img = Nifti2Image(data, None, header)
         img.to_filename(filename)

--- a/nibabel/cifti/parse_cifti_fast.py
+++ b/nibabel/cifti/parse_cifti_fast.py
@@ -10,7 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 from distutils.version import LooseVersion
 
-from ..externals.six import StringIO
+from ..externals.six import BytesIO
 from xml.parsers.expat import ParserCreate, ExpatError
 
 import numpy as np
@@ -306,25 +306,25 @@ class Outputter(object):
             pair[1] = data
         elif self.write_to == 'Vertices':
             # conversion to numpy array
-            c = StringIO(data.strip().decode('utf-8'))
+            c = BytesIO(data.strip().encode())
             vertices = self.struct_state[-1]
             vertices.vertices = np.genfromtxt(c, dtype=np.int)
             c.close()
         elif self.write_to == 'VoxelIndices':
             # conversion to numpy array
-            c = StringIO(data.strip().decode('utf-8'))
+            c = BytesIO(data.strip().encode())
             parent = self.struct_state[-1]
             parent.voxelIndicesIJK.indices = np.genfromtxt(c, dtype=np.int)
             c.close()
         elif self.write_to == 'VertexIndices':
             # conversion to numpy array
-            c = StringIO(data.strip())
+            c = BytesIO(data.strip().encode())
             index = self.struct_state[-1]
             index.indices = np.genfromtxt(c, dtype=np.int)
             c.close()
         elif self.write_to == 'TransformMatrix':
             # conversion to numpy array
-            c = StringIO(data.strip())
+            c = BytesIO(data.strip().encode())
             transform = self.struct_state[-1]
             transform.matrix = np.genfromtxt(c, dtype=np.float)
             c.close()


### PR DESCRIPTION
I made two changes to ensure that your code works in python3:
1. replaced `basestring` with `six.string_types`
2. replaced `six.StringIO` with `six.BytesIO`, which is the object expected by `np.genfromtxt` in python3 (in python2 these objects are the same)
