### PR TITLE
Enh/cifti2 python3 compatibility

### DIFF
--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -24,6 +24,7 @@ import numpy as np
 from .. import xmlutils as xml
 from ..externals import inflection
 from ..externals.six import string_types
+from ..externals.six.moves import reduce
 from ..filebasedimages import FileBasedHeader, FileBasedImage
 from ..nifti2 import Nifti2Image
 

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -770,7 +770,7 @@ class Cifti2Image(FileBasedImage):
         """
         from .parse_cifti2_fast import Cifti2Extension
         header = self.extra
-        extension = Cifti2Extension(content=self.header.to_xml().encode())
+        extension = Cifti2Extension(content=self.header.to_xml())
         header.extensions.append(extension)
         data = np.reshape(self.data, [1, 1, 1, 1] + list(self.data.shape))
         img = Nifti2Image(data, None, header)

--- a/nibabel/cifti2/parse_cifti2_fast.py
+++ b/nibabel/cifti2/parse_cifti2_fast.py
@@ -22,6 +22,7 @@ from .cifti2 import (Cifti2MetaData, Cifti2Header, Cifti2Label,
 from .. import xmlutils as xml
 from ..externals import inflection
 from ..externals.six import BytesIO
+from ..externals.six.moves import reduce
 from ..nifti1 import Nifti1Extension, extension_codes, intent_codes
 from ..nifti2 import Nifti2Header, Nifti2Image
 


### PR DESCRIPTION
Thanks @bcipolli and @satra for all the great work on getting CIFTI into nibabel. There are a few errors raised by the tests if run in python 3, which should be fixed by this patch.
