### PR TITLE
FIX: allow applies_to_matrix_dimension to be a comma-seperate list

### DIFF
--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -482,7 +482,7 @@ class Cifti2MatrixIndicesMap(object):
 
     Provides a mapping between matrix indices and their interpretation.
     """
-    # applies_to_matrix_dimension = int
+    # applies_to_matrix_dimension = list
     # indices_map_to_data_type = str
     # number_of_series_points = int
     # series_exponent = int
@@ -594,9 +594,10 @@ class Cifti2MatrixIndicesMap(object):
         assert self.applies_to_matrix_dimension is not None
 
         mat_ind_map = xml.Element('MatrixIndicesMap')
-        for key in ['AppliesToMatrixDimension', 'IndicesMapToDataType',
-                    'NumberOfSeriesPoints', 'SeriesExponent', 'SeriesStart',
-                    'SeriesStep', 'SeriesUnit']:
+        dims_as_strings = [str(dim) for dim in self.applies_to_matrix_dimension]
+        mat_ind_map.attrib['AppliesToMatrixDimension'] = ','.join(dims_as_strings)
+        for key in ['IndicesMapToDataType', 'NumberOfSeriesPoints', 'SeriesExponent',
+                    'SeriesStart', 'SeriesStep', 'SeriesUnit']:
             attr = inflection.underscore(key)
             value = getattr(self, attr)
             if value is not None:

--- a/nibabel/cifti2/parse_cifti2_fast.py
+++ b/nibabel/cifti2/parse_cifti2_fast.py
@@ -172,8 +172,9 @@ class Cifti2Parser(xml.XmlParser):
 
         elif name == 'MatrixIndicesMap':
             self.fsm_state.append('MatrixIndicesMap')
+            dimensions = [int(value) for value in attrs["AppliesToMatrixDimension"].split(',')]
             mim = Cifti2MatrixIndicesMap(
-                applies_to_matrix_dimension=int(attrs["AppliesToMatrixDimension"]),
+                applies_to_matrix_dimension=dimensions,
                 indices_map_to_data_type=attrs["IndicesMapToDataType"])
             for key, dtype in [("NumberOfSeriesPoints", int),
                                ("SeriesExponent", int),


### PR DESCRIPTION
According to the CIFTI format definition: "an AppliesToMatrixDimension attribute, which is a comma separated list of the data matrix dimension(s) to which this particular mapping applies."

I think this bug only arises for dense connectomes, where both dimensions often are the same (i.e. grayordinate space) and hence only a single mapping is defined by the HCP workbench and the AppliesToMatrixDimension is set to "0,1". Unfortunately, these dense connectomes are huge (typically 30 GB), so I can't upload any for testing.
