### PR TITLE
MRG: refactor CIFTI / NIFTI header checking

### DIFF
--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -5,15 +5,9 @@ from xml.etree import ElementTree
 
 import numpy as np
 
-from ...nifti1 import data_type_codes, intent_codes
+from nibabel import cifti2 as ci
 
-from ... import cifti2 as ci
-
-from numpy.testing import (assert_array_almost_equal,
-                           assert_array_equal)
-
-from nose.tools import assert_true, assert_equal, assert_raises, assert_is_none
-
+from nose.tools import assert_equal, assert_raises, assert_is_none
 
 
 def compare_xml_leaf(str1, str2):
@@ -26,6 +20,7 @@ def compare_xml_leaf(str1, str2):
     print((x1.tag, x1.attrib, x1.text))
     print((x2.tag, x2.attrib, x2.text))
     return test
+
 
 def test_cifti2_metadata():
     md = ci.Cifti2MetaData()
@@ -61,6 +56,7 @@ def test_cifti2_metadata():
     assert_equal(md.to_xml().decode('utf-8'),
                  '<MetaData><MD><Name>b</Name><Value>bval</Value></MD></MetaData>')
 
+
 def test_cifti2_labeltable():
     lt = ci.Cifti2LabelTable()
     assert_equal(len(lt), 0)
@@ -88,7 +84,6 @@ def test_cifti2_labeltable():
 
     assert_raises(ValueError, lt.__setitem__, 1, label)
     assert_raises(ValueError, lt.__setitem__, 0, test_tuple[:-1])
-
 
 
 def test_cifti2_label():
@@ -120,10 +115,12 @@ def test_cifti2_label():
     assert_raises(ci.CIFTI2HeaderError, lb.to_xml)
     lb.key = 0
 
+
 def test_cifti2_parcel():
     pl = ci.Cifti2Parcel()
     assert_raises(ci.CIFTI2HeaderError, pl.to_xml)
     assert_raises(TypeError, pl.append_cifti_vertices, None)
+
 
 def test_cifti2_vertices():
     vs = ci.Cifti2Vertices()
@@ -146,17 +143,21 @@ def test_cifti2_vertices():
     assert_equal(vs[0], 10)
     assert_equal(len(vs), 3)
 
+
 def test_cifti2_transformationmatrixvoxelindicesijktoxyz():
     tr = ci.Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ()
     assert_raises(ci.CIFTI2HeaderError, tr.to_xml)
+
 
 def test_cifti2_surface():
     s = ci.Cifti2Surface()
     assert_raises(ci.CIFTI2HeaderError, s.to_xml)
 
+
 def test_cifti2_volume():
     vo = ci.Cifti2Volume()
     assert_raises(ci.CIFTI2HeaderError, vo.to_xml)
+
 
 def test_cifti2_vertexindices():
     vi = ci.Cifti2VertexIndices()
@@ -172,7 +173,7 @@ def test_cifti2_vertexindices():
     vi[0] = 10
     assert_equal(vi[0], 10)
     assert_equal(len(vi), 3)
-    
+
 
 def test_cifti2_voxelindicesijk():
     vi = ci.Cifti2VoxelIndicesIJK()
@@ -214,6 +215,7 @@ def test_cifti2_voxelindicesijk():
         '<VoxelIndicesIJK>0 1 2\n3 4 6</VoxelIndicesIJK>'
     )
 
+
 def test_matrixindicesmap():
     mim = ci.Cifti2MatrixIndicesMap(0, 'CIFTI_INDEX_TYPE_LABELS')
     volume = ci.Cifti2Volume()
@@ -242,6 +244,7 @@ def test_matrixindicesmap():
     assert_equal(mim.volume, volume2)
 
     assert_raises(ValueError, setattr, mim, 'volume', parcel)
+
 
 def test_matrix():
     m = ci.Cifti2Matrix()

--- a/nibabel/cifti2/tests/test_cifti2io.py
+++ b/nibabel/cifti2/tests/test_cifti2io.py
@@ -9,20 +9,16 @@
 from __future__ import division, print_function, absolute_import
 
 from os.path import join as pjoin, dirname
-import sys
 import io
 from distutils.version import LooseVersion
-
-import numpy as np
 
 import nibabel as nib
 from nibabel import cifti2 as ci
 from nibabel.tmpdirs import InTemporaryDirectory
 from nibabel.tests.nibabel_data import get_nibabel_data, needs_nibabel_data
 
-from numpy.testing import assert_array_equal, assert_array_almost_equal
-from nose.tools import (assert_true, assert_false, assert_equal,
-                        assert_raises)
+from numpy.testing import assert_array_almost_equal
+from nose.tools import (assert_true, assert_equal, assert_raises)
 
 NIBABEL_TEST_DATA = pjoin(dirname(nib.__file__), 'tests', 'data')
 NIFTI2_DATA = pjoin(NIBABEL_TEST_DATA, 'example_nifti2.nii.gz')
@@ -48,11 +44,13 @@ def test_read_nifti2():
         filemap[k].fileobj = io.open(NIFTI2_DATA)
     assert_raises(ValueError, ci.Cifti2Image.from_file_map, filemap)
 
+
 @needs_nibabel_data('nitest-cifti2')
 def test_read_internal():
     img2 = ci.load(DATA_FILE6)
     assert_true(isinstance(img2.header, ci.Cifti2Header))
     assert_equal(img2.shape, (1, 91282))
+
 
 @needs_nibabel_data('nitest-cifti2')
 def test_read():
@@ -60,11 +58,13 @@ def test_read():
     assert_true(isinstance(img2.header, ci.Cifti2Header))
     assert_equal(img2.shape, (1, 91282))
 
+
 @needs_nibabel_data('nitest-cifti2')
 def test_version():
     for i, dat in enumerate(datafiles):
         img = nib.load(dat)
         assert_equal(LooseVersion(img.header.version), LooseVersion('2'))
+
 
 @needs_nibabel_data('nitest-cifti2')
 def test_readwritedata():
@@ -78,8 +78,10 @@ def test_readwritedata():
             # Order should be preserved in load/save
             for mim1, mim2 in zip(img.header.matrix,
                                   img2.header.matrix):
-                named_maps1 = [m_ for m_ in mim1 if isinstance(m_, ci.Cifti2NamedMap)]
-                named_maps2 = [m_ for m_ in mim2 if isinstance(m_, ci.Cifti2NamedMap)]
+                named_maps1 = [m_ for m_ in mim1
+                               if isinstance(m_, ci.Cifti2NamedMap)]
+                named_maps2 = [m_ for m_ in mim2
+                               if isinstance(m_, ci.Cifti2NamedMap)]
                 assert_equal(len(named_maps1), len(named_maps2))
                 for map1, map2 in zip(named_maps1, named_maps2):
                     assert_equal(map1.map_name, map2.map_name)
@@ -103,8 +105,10 @@ def test_nibabel_readwritedata():
             # Order should be preserved in load/save
             for mim1, mim2 in zip(img.header.matrix,
                                   img2.header.matrix):
-                named_maps1 = [m_ for m_ in mim1 if isinstance(m_, ci.Cifti2NamedMap)]
-                named_maps2 = [m_ for m_ in mim2 if isinstance(m_, ci.Cifti2NamedMap)]
+                named_maps1 = [m_ for m_ in mim1
+                               if isinstance(m_, ci.Cifti2NamedMap)]
+                named_maps2 = [m_ for m_ in mim2
+                               if isinstance(m_, ci.Cifti2NamedMap)]
                 assert_equal(len(named_maps1), len(named_maps2))
                 for map1, map2 in zip(named_maps1, named_maps2):
                     assert_equal(map1.map_name, map2.map_name)
@@ -148,7 +152,8 @@ def test_cifti2types():
                     counter[ci.Cifti2BrainModel] += 1
                     if isinstance(map_.vertex_indices, ci.Cifti2VertexIndices):
                         counter[ci.Cifti2VertexIndices] += 1
-                    if isinstance(map_.voxel_indices_ijk, ci.Cifti2VoxelIndicesIJK):
+                    if isinstance(map_.voxel_indices_ijk,
+                                  ci.Cifti2VoxelIndicesIJK):
                         counter[ci.Cifti2VoxelIndicesIJK] += 1
                 elif isinstance(map_, ci.Cifti2NamedMap):
                     counter[ci.Cifti2NamedMap] += 1
@@ -156,7 +161,8 @@ def test_cifti2types():
                     if isinstance(map_.label_table, ci.Cifti2LabelTable):
                         counter[ci.Cifti2LabelTable] += 1
                         for label in map_.label_table:
-                            assert_true(isinstance(map_.label_table[label], ci.Cifti2Label))
+                            assert_true(isinstance(map_.label_table[label],
+                                                   ci.Cifti2Label))
                             counter[ci.Cifti2Label] += 1
                 elif isinstance(map_, ci.Cifti2Parcel):
                     counter[ci.Cifti2Parcel] += 1
@@ -175,11 +181,16 @@ def test_cifti2types():
                                   ci.Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ):
                         counter[ci.Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ] += 1
 
-            assert_equal(list(mim.named_maps), [m_ for m_ in mim if isinstance(m_, ci.Cifti2NamedMap)])
-            assert_equal(list(mim.surfaces), [m_ for m_ in mim if isinstance(m_, ci.Cifti2Surface)])
-            assert_equal(list(mim.parcels), [m_ for m_ in mim if isinstance(m_, ci.Cifti2Parcel)])
-            assert_equal(list(mim.brain_models), [m_ for m_ in mim if isinstance(m_, ci.Cifti2BrainModel)])
-            assert_equal([mim.volume] if mim.volume else [], [m_ for m_ in mim if isinstance(m_, ci.Cifti2Volume)])
+            assert_equal(list(mim.named_maps),
+                         [m_ for m_ in mim if isinstance(m_, ci.Cifti2NamedMap)])
+            assert_equal(list(mim.surfaces),
+                         [m_ for m_ in mim if isinstance(m_, ci.Cifti2Surface)])
+            assert_equal(list(mim.parcels),
+                         [m_ for m_ in mim if isinstance(m_, ci.Cifti2Parcel)])
+            assert_equal(list(mim.brain_models),
+                         [m_ for m_ in mim if isinstance(m_, ci.Cifti2BrainModel)])
+            assert_equal([mim.volume] if mim.volume else [],
+                         [m_ for m_ in mim if isinstance(m_, ci.Cifti2Volume)])
 
     for klass, count in counter.items():
         assert_true(count > 0, "No exercise of " + klass.__name__)

--- a/nibabel/tests/test_nifti1.py
+++ b/nibabel/tests/test_nifti1.py
@@ -186,17 +186,25 @@ class TestNifti1PairHeader(tana.TestAnalyzeHeader, tspm.HeaderScalingMixin):
             assert_array_equal([hdr['scl_slope'], hdr['scl_inter']],
                                raw_values)
 
-    def test_nifti_qsform_checks(self):
-        # qfac, qform, sform checks
-        # qfac
-        HC = self.header_class
-        hdr = HC()
+    def test_nifti_qfac_checks(self):
+        # Test qfac is 1 or -1
+        hdr = self.header_class()
+        # 1, -1 OK
+        hdr['pixdim'][0] = 1
+        self.log_chk(hdr, 0)
+        hdr['pixdim'][0] = -1
+        self.log_chk(hdr, 0)
+        # 0 is not
         hdr['pixdim'][0] = 0
         fhdr, message, raiser = self.log_chk(hdr, 20)
         assert_equal(fhdr['pixdim'][0], 1)
         assert_equal(message,
                      'pixdim[0] (qfac) should be 1 '
                      '(default) or -1; setting qfac to 1')
+
+    def test_nifti_qsform_checks(self):
+        # qform, sform checks
+        HC = self.header_class
         # qform, sform
         hdr = HC()
         hdr['qform_code'] = -1

--- a/nibabel/tests/test_nifti2.py
+++ b/nibabel/tests/test_nifti2.py
@@ -78,11 +78,6 @@ class TestNifti2Image(TestNifti1Image):
     image_class = Nifti2Image
 
 
-class TestNifti2Image(TestNifti1Image):
-    # Run analyze-flavor spatialimage tests
-    image_class = Nifti2Image
-
-
 class TestNifti2Pair(TestNifti1Pair):
     # Run analyze-flavor spatialimage tests
     image_class = Nifti2Pair

--- a/nibabel/wrapstruct.py
+++ b/nibabel/wrapstruct.py
@@ -346,7 +346,15 @@ class WrapStruct(object):
         return (k in self.keys()) and self._structarr[k] or d
 
     def check_fix(self, logger=None, error_level=None):
-        ''' Check structured data with checks '''
+        ''' Check structured data with checks
+
+        Parameters
+        ----------
+        logger : None or logging.Logger
+        error_level : None or int
+            Level of error severity at which to raise error.  Any error of
+            severity >= `error_level` will cause an exception.
+        '''
         if logger is None:
             logger = imageglobals.logger
         if error_level is None:


### PR DESCRIPTION
Refactor CIFTI header checking to use NIFTI header checking test machinery.
Add qfac check that allows zero.  Add pixdim checks that allow zero.  Refactor
nifti and analyze checks to make this possible.
