### PR TITLE
WIP: refactor nibabel for Cifti2 array proxies

### DIFF
--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -113,8 +113,12 @@ class ArrayProxy(object):
         return self._shape
 
     @property
-    def is_proxy(self):
-        return True
+    def dtype(self):
+        return self._dtype
+
+    @property
+    def offset(self):
+        return self._offset
 
     @property
     def slope(self):
@@ -125,8 +129,8 @@ class ArrayProxy(object):
         return self._inter
 
     @property
-    def offset(self):
-        return self._offset
+    def is_proxy(self):
+        return True
 
     def get_unscaled(self):
         ''' Read of data from file

--- a/nibabel/arrayproxy.py
+++ b/nibabel/arrayproxy.py
@@ -27,6 +27,8 @@ See :mod:`nibabel.tests.test_proxy_api` for proxy API conformance checks.
 """
 import warnings
 
+import numpy as np
+
 from .volumeutils import array_from_file, apply_read_scaling
 from .fileslice import fileslice
 from .keywordonly import kw_only_meth
@@ -164,3 +166,10 @@ def is_proxy(obj):
         return obj.is_proxy
     except AttributeError:
         return False
+
+
+def reshape_dataobj(obj, shape):
+    """ Use `obj` reshape method if possible, else numpy reshape function
+    """
+    return (obj.reshape(shape) if hasattr(obj, 'reshape')
+            else np.reshape(obj, shape))

--- a/nibabel/cifti2/__init__.py
+++ b/nibabel/cifti2/__init__.py
@@ -21,6 +21,7 @@ from .cifti2 import (Cifti2MetaData, Cifti2Header, Cifti2Image, Cifti2Label,
                      Cifti2LabelTable, Cifti2VertexIndices,
                      Cifti2VoxelIndicesIJK, Cifti2BrainModel, Cifti2Matrix,
                      Cifti2MatrixIndicesMap, Cifti2NamedMap, Cifti2Parcel,
-                     Cifti2Surface, Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ,
-                     Cifti2Vertices, Cifti2Volume, CIFTI_BrainStructures, CIFTI2HeaderError,
-                     CIFTI_MODEL_TYPES, load, save)
+                     Cifti2Surface,
+                     Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ,
+                     Cifti2Vertices, Cifti2Volume, CIFTI_BRAIN_STRUCTURES,
+                     CIFTI2HeaderError, CIFTI_MODEL_TYPES, load, save)

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -12,10 +12,12 @@ Format of the NIFTI2 container format described here:
 
     http://www.nitrc.org/forum/message.php?msg_id=3738
 
-Definition of the CIFTI2 header format and file extensions here:
+Definition of the CIFTI2 header format and file extensions attached to this
+email:
 
-    https://www.nitrc.org/forum/attachment.php?attachid=333&group_id=454&forum_id=1955
+    http://www.nitrc.org/forum/forum.php?thread_id=4380&forum_id=1955
 
+Filename is ``CIFTI-2_Main_FINAL_1March2014.pdf``.
 '''
 from __future__ import division, print_function, absolute_import
 import re
@@ -103,6 +105,18 @@ def _underscore(string):
 class Cifti2MetaData(xml.XmlSerializable, collections.MutableMapping):
     """ A list of name-value pairs
 
+    * Description - Provides a simple method for user-supplied metadata that
+      associates names with values.
+    * Attributes: [NA]
+    * Child Elements
+
+        * MD (0...N)
+
+    * Text Content: [NA]
+    * Parent Elements - Matrix, NamedMap
+
+    MD elements are a single metadata entry consisting of a name and a value.
+
     Attributes
     ----------
     data : list of (name, value) tuples
@@ -159,6 +173,16 @@ class Cifti2MetaData(xml.XmlSerializable, collections.MutableMapping):
 
 class Cifti2LabelTable(xml.XmlSerializable, collections.MutableMapping):
     """ Cifti2 label table: a sequence of ``Cifti2Label``s
+
+    * Description - Used by NamedMap when IndicesMapToDataType is
+      "CIFTI_INDEX_TYPE_LABELS" in order to associate names and display colors
+      with label keys. Note that LABELS is the only mapping type that uses a
+      LabelTable. Display coloring of continuous-valued data is not specified
+      by CIFTI-2.
+    * Attributes: [NA]
+    * Child Elements - Label (0...N)
+    * Text Content: [NA]
+    * Parent Element - NamedMap
     """
 
     def __init__(self):
@@ -205,8 +229,25 @@ class Cifti2LabelTable(xml.XmlSerializable, collections.MutableMapping):
 class Cifti2Label(xml.XmlSerializable):
     """ Cifti2 label: association of integer key with a name and RGBA values
 
-    Attribute descriptions are from the CIFTI-2 spec dated 2014-03-01.
     For all color components, value is floating point with range 0.0 to 1.0.
+
+    * Description - Associates a label key value with a name and a display
+      color.
+    * Attributes
+
+        * Key - Integer, data value which is assigned this name and color.
+        * Red - Red color component for label. Value is floating point with
+          range 0.0 to 1.0.
+        * Green - Green color component for label. Value is floating point with
+          range 0.0 to 1.0.
+        * Blue - Blue color component for label. Value is floating point with
+          range 0.0 to 1.0.
+        * Alpha - Alpha color component for label. Value is floating point with
+          range 0.0 to 1.0.
+
+    * Child Elements: [NA]
+    * Text Content - Name of the label.
+    * Parent Element - LabelTable
 
     Attributes
     ----------
@@ -268,6 +309,18 @@ class Cifti2NamedMap(xml.XmlSerializable):
 
     Associates a name, optional metadata, and possibly a LabelTable with an
     index in a map.
+
+    * Description - Associates a name, optional metadata, and possibly a
+      LabelTable with an index in a map.
+    * Attributes: [NA]
+    * Child Elements
+
+        * MapName (1)
+        * LabelTable (0...1)
+        * MetaData (0...1)
+
+    * Text Content: [NA]
+    * Parent Element - MatrixIndicesMap
 
     Attributes
     ----------
@@ -333,10 +386,21 @@ class Cifti2NamedMap(xml.XmlSerializable):
 class Cifti2Surface(xml.XmlSerializable):
     """Cifti surface: association of brain structure and number of vertices
 
-    "Specifies the number of vertices for a surface, when IndicesMapToDataType
-    is 'CIFTI_INDEX_TYPE_PARCELS.' This is separate from the Parcel element
-    because there can be multiple parcels on one surface, and one parcel may
-    involve multiple surfaces."
+    * Description - Specifies the number of vertices for a surface, when
+      IndicesMapToDataType is "CIFTI_INDEX_TYPE_PARCELS." This is separate from
+      the Parcel element because there can be multiple parcels on one surface,
+      and one parcel may involve multiple surfaces.
+    * Attributes
+
+        * BrainStructure - A string from the BrainStructure list to identify
+          what surface structure this element refers to (usually left cortex,
+          right cortex, or cerebellum).
+        * SurfaceNumberOfVertices - The number of vertices that this
+          structure's surface contains.
+
+    * Child Elements: [NA]
+    * Text Content: [NA]
+    * Parent Element - MatrixIndicesMap
 
     Attributes
     ----------
@@ -361,10 +425,18 @@ class Cifti2Surface(xml.XmlSerializable):
 class Cifti2VoxelIndicesIJK(xml.XmlSerializable, collections.MutableSequence):
     """Cifti2 VoxelIndicesIJK: Set of voxel indices contained in a structure
 
-    "Identifies the voxels that model a brain structure, or participate in a
-    parcel. Note that when this is a child of BrainModel, the IndexCount
-    attribute of the BrainModel indicates the number of voxels contained in
-    this element."
+    * Description - Identifies the voxels that model a brain structure, or
+      participate in a parcel. Note that when this is a child of BrainModel,
+      the IndexCount attribute of the BrainModel indicates the number of voxels
+      contained in this element.
+    * Attributes: [NA]
+    * Child Elements: [NA]
+    * Text Content - IJK indices (which are zero-based) of each voxel in this
+      brain model or parcel, with each index separated by a whitespace
+      character. There are three indices per voxel.  If the parent element is
+      BrainModel, then the BrainModel element's IndexCount attribute indicates
+      the number of triplets (IJK indices) in this element's content.
+    * Parent Elements - BrainModel, Parcel
 
     Each element of this sequence is a triple of integers.
     """
@@ -435,12 +507,21 @@ class Cifti2VoxelIndicesIJK(xml.XmlSerializable, collections.MutableSequence):
 class Cifti2Vertices(xml.XmlSerializable, collections.MutableSequence):
     """Cifti2 vertices - association of brain structure and a list of vertices
 
-    "Contains a BrainStructure type and a list of vertex indices within a
-    Parcel."
+    * Description - Contains a BrainStructure type and a list of vertex indices
+      within a Parcel.
+    * Attributes
 
-    Attribute descriptions are from the CIFTI-2 spec dated 2014-03-01.
-    The class behaves like a list of Vertex indices
-    (which are independent for each surface, and zero-based)
+        * BrainStructure - A string from the BrainStructure list to identify
+          what surface this vertex list is from (usually left cortex, right
+          cortex, or cerebellum).
+
+    * Child Elements: [NA]
+    * Text Content - Vertex indices (which are independent for each surface,
+      and zero-based) separated by whitespace characters.
+    * Parent Element - Parcel
+
+    The class behaves like a list of Vertex indices (which are independent for
+    each surface, and zero-based)
 
     Attributes
     ----------
@@ -491,6 +572,20 @@ class Cifti2Vertices(xml.XmlSerializable, collections.MutableSequence):
 
 class Cifti2Parcel(xml.XmlSerializable):
     """Cifti2 parcel: association of a name with vertices and/or voxels
+
+    * Description - Associates a name, plus vertices and/or voxels, with an
+      index.
+    * Attributes
+
+        * Name - The name of the parcel
+
+    * Child Elements
+
+        * Vertices (0...N)
+        * VoxelIndicesIJK (0...1)
+
+    * Text Content: [NA]
+    * Parent Element - MatrixIndicesMap
 
     Attributes
     ----------
@@ -545,15 +640,27 @@ class Cifti2Parcel(xml.XmlSerializable):
 class Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ(xml.XmlSerializable):
     """Matrix that translates voxel indices to spatial coordinates
 
+    * Description - Contains a matrix that translates Voxel IJK Indices to
+      spatial XYZ coordinates (+X=>right, +Y=>anterior, +Z=> superior). The
+      resulting coordinate is the center of the voxel.
+    * Attributes
+
+        * MeterExponent - Integer, specifies that the coordinate result from
+          the transformation matrix should be multiplied by 10 to this power to
+          get the spatial coordinates in meters (e.g., if this is "-3", then
+          the transformation matrix is in millimeters).
+
+    * Child Elements: [NA]
+    * Text Content - Sixteen floating-point values, in row-major order, that
+      form a 4x4 homogeneous transformation matrix.
+    *  Parent Element - Volume
+
     Attributes
     ----------
     meter_exponent : int
-        "[S]pecifies that the coordinate result from the transformation matrix
-        should be multiplied by 10 to this power to get the spatial coordinates
-        in meters (e.g., if this is '-3', then the transformation matrix is in
-        millimeters)."
+        See attribute description above.
     matrix : array-like shape (4, 4)
-        Affine transformation matrix from voxel indices to RAS space
+        Affine transformation matrix from voxel indices to RAS space.
     """
     # meterExponent = int
     # matrix = np.array
@@ -577,13 +684,27 @@ class Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ(xml.XmlSerializable):
 class Cifti2Volume(xml.XmlSerializable):
     """Cifti2 volume: information about a volume for mappings that use voxels
 
+    * Description - Provides information about the volume for any mappings that
+      use voxels.
+    * Attributes
+
+        * VolumeDimensions - Three integer values separated by commas, the
+          lengths of the three volume file dimensions that are related to
+          spatial coordinates, in number of voxels. Voxel indices (which are
+          zero-based) that are used in the mapping that this element applies to
+          must be within these dimensions.
+
+    * Child Elements
+
+        * TransformationMatrixVoxelIndicesIJKtoXYZ (1)
+
+    * Text Content: [NA]
+    * Parent Element - MatrixIndicesMap
+
     Attributes
     ----------
     volume_dimensions : array-like shape (3,)
-        "[T]he lengthss of the three volume file dimensions that are related to
-        spatial coordinates, in number of voxels. Voxel indices (which are
-        zero-based) that are used in the mapping that this element applies to
-        must be within these dimensions."
+        See attribute description above.
     transformation_matrix_voxel_indices_ijk_to_xyz \
         : Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ
         Matrix that translates voxel indices to spatial coordinates
@@ -609,6 +730,17 @@ class Cifti2VertexIndices(xml.XmlSerializable, collections.MutableSequence):
     The vertex indices (which are independent for each surface, and
     zero-based) that are used in this brain model[.] The parent
     BrainModel's ``index_count`` indicates the number of indices.
+
+    * Description - Contains a list of vertex indices for a BrainModel with
+      ModelType equal to CIFTI_MODEL_TYPE_SURFACE.
+    * Attributes: [NA]
+    * Child Elements: [NA]
+    * Text Content - The vertex indices (which are independent for each
+      surface, and zero-based) that are used in this brain model, with each
+      index separated by a whitespace character.  The parent BrainModel's
+      IndexCount attribute indicates the number of indices in this element's
+      content.
+    * Parent Element - BrainModel
     """
     def __init__(self, indices=None):
         self._indices = []
@@ -648,26 +780,106 @@ class Cifti2VertexIndices(xml.XmlSerializable, collections.MutableSequence):
 
 
 class Cifti2BrainModel(xml.XmlSerializable):
-    '''
-    BrainModel element representing a mapping of the dimension to vertex or voxels.
+    ''' Element representing a mapping of the dimension to vertex or voxels.
+
     Mapping to vertices of voxels must be specified.
+
+    * Description - Maps a range of indices to surface vertices or voxels when
+      IndicesMapToDataType is "CIFTI_INDEX_TYPE_BRAIN_MODELS."
+    * Attributes
+
+        * IndexOffset - The matrix index of the first brainordinate of this
+          BrainModel. Note that matrix indices are zero-based.
+        * IndexCount - Number of surface vertices or voxels in this brain
+          model, must be positive.
+        * ModelType - Type of model representing the brain structure (surface
+        * or voxels).  Valid values are listed in the table below.
+        * BrainStructure - Identifies the brain structure. Valid values for
+          BrainStructure are listed in the table below. However, if the needed
+          structure is not listed in the table, a message should be posted to
+          the CIFTI Forum so that a standardized name can be created for the
+          structure and added to the table.
+        * SurfaceNumberOfVertices - When ModelType is CIFTI_MODEL_TYPE_SURFACE
+          this attribute contains the actual (or true) number of vertices in
+          the surface that is associated with this BrainModel. When this
+          BrainModel represents all vertices in the surface, this value is the
+          same as IndexCount. When this BrainModel represents only a subset of
+          the surface's vertices, IndexCount will be less than this value.
+
+    * Child Elements
+
+        * VertexIndices (0...1)
+        * VoxelIndicesIJK (0...1)
+
+    * Text Content: [NA]
+    * Parent Element - MatrixIndicesMap
+
+    ModelType Values
+    ----------------
+
+    =========================  ================================
+    ModelType                  Description
+    =========================  ================================
+    CIFTI_MODEL_TYPE_SURFACE   Modeled using surface vertices.
+    CIFTI_MODEL_TYPE_VOXELS    Modeled using voxels.
+    =========================  ================================
+
+    BrainStructure Values
+    ---------------------
+
+    =============================================
+    BrainStructure
+    =============================================
+    CIFTI_STRUCTURE_ACCUMBENS_LEFT
+    CIFTI_STRUCTURE_ACCUMBENS_RIGHT
+    CIFTI_STRUCTURE_ALL_WHITE_MATTER
+    CIFTI_STRUCTURE_ALL_GREY_MATTER
+    CIFTI_STRUCTURE_AMYGDALA_LEFT
+    CIFTI_STRUCTURE_AMYGDALA_RIGHT
+    CIFTI_STRUCTURE_BRAIN_STEM
+    CIFTI_STRUCTURE_CAUDATE_LEFT
+    CIFTI_STRUCTURE_CAUDATE_RIGHT
+    CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_LEFT
+    CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_RIGHT
+    CIFTI_STRUCTURE_CEREBELLUM
+    CIFTI_STRUCTURE_CEREBELLUM_LEFT
+    CIFTI_STRUCTURE_CEREBELLUM_RIGHT
+    CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_LEFT
+    CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_RIGHT
+    CIFTI_STRUCTURE_CORTEX
+    CIFTI_STRUCTURE_CORTEX_LEFT
+    CIFTI_STRUCTURE_CORTEX_RIGHT
+    CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT
+    CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT
+    CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT
+    CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT
+    CIFTI_STRUCTURE_OTHER
+    CIFTI_STRUCTURE_OTHER_GREY_MATTER
+    CIFTI_STRUCTURE_OTHER_WHITE_MATTER
+    CIFTI_STRUCTURE_PALLIDUM_LEFT
+    CIFTI_STRUCTURE_PALLIDUM_RIGHT
+    CIFTI_STRUCTURE_PUTAMEN_LEFT
+    CIFTI_STRUCTURE_PUTAMEN_RIGHT
+    CIFTI_STRUCTURE_THALAMUS_LEFT
+    CIFTI_STRUCTURE_THALAMUS_RIGHT
+    =============================================
 
     Attributes
     ----------
-        index_offset : int
-            Start of the mapping
-        index_count : int
-            Number of elements in the array to be mapped
-        model_type : str
-            One of CIFTI_MODEL_TYPES
-        brain_structure : str
-            One of CIFTI_BrainStructures
-        surface_number_of_vertices : int
-            Number of vertices in the surface. Use only for surface-type structure
-        voxel_indices_ijk : Cifti2VoxelIndicesIJK, optional
-            Indices on the image towards where the array indices are mapped
-        vertex_indices : Cifti2VertexIndices, optional
-            Indices of the vertices towards where the array indices are mapped
+    index_offset : int
+        Start of the mapping
+    index_count : int
+        Number of elements in the array to be mapped
+    model_type : str
+        One of CIFTI_MODEL_TYPES
+    brain_structure : str
+        One of CIFTI_BrainStructures
+    surface_number_of_vertices : int
+        Number of vertices in the surface. Use only for surface-type structure
+    voxel_indices_ijk : Cifti2VoxelIndicesIJK, optional
+        Indices on the image towards where the array indices are mapped
+    vertex_indices : Cifti2VertexIndices, optional
+        Indices of the vertices towards where the array indices are mapped
     '''
 
     def __init__(self, index_offset=None, index_count=None, model_type=None,
@@ -717,24 +929,59 @@ class Cifti2BrainModel(xml.XmlSerializable):
 class Cifti2MatrixIndicesMap(xml.XmlSerializable, collections.MutableSequence):
     """Class for Matrix Indices Map
 
-    Provides a mapping between matrix indices and their interpretation.
+    * Description - Provides a mapping between matrix indices and their
+      interpretation.
+    * Attributes
+
+        * AppliesToMatrixDimension - Lists the dimension(s) of the matrix to
+          which this MatrixIndicesMap applies. The dimensions of the matrix
+          start at zero (dimension 0 describes the indices along the first
+          dimension, dimension 1 describes the indices along the second
+          dimension, etc.). If this MatrixIndicesMap applies to more than one
+          matrix dimension, the values are separated by a comma.
+        * IndicesMapToDataType - Type of data to which the MatrixIndicesMap
+          applies.
+        * NumberOfSeriesPoints - Indicates how many samples there are in a
+          series mapping type. For example, this could be the number of
+          timepoints in a timeseries.
+        * SeriesExponent - Integer, SeriesStart and SeriesStep must be
+          multiplied by 10 raised to the power of the value of this attribute
+          to give the actual values assigned to indices (e.g., if SeriesStart
+          is "5" and SeriesExponent is "-3", the value of the first series
+          point is 0.005).
+        * SeriesStart - Indicates what quantity should be assigned to the first
+          series point.
+        * SeriesStep - Indicates amount of change between each series point.
+        * SeriesUnit - Indicates the unit of the result of multiplying
+          SeriesStart and SeriesStep by 10 to the power of SeriesExponent.
+
+    * Child Elements
+
+        * BrainModel (0...N)
+        * NamedMap (0...N)
+        * Parcel (0...N)
+        * Surface (0...N)
+        * Volume (0...1)
+
+    * Text Content: [NA]
+    * Parent Element - Matrix
 
     Attribute
     ---------
-        applies_to_matrix_dimension : list of ints
-            Dimensions of this matrix that follow this mapping
-        indices_map_to_data_type : str one of CIFTI_MAP_TYPES
-            Type of mapping to the matrix indices
-        number_of_series_points : int, optional
-            If it is a series, number of points in the series
-        series_exponent : int, optional
-            If it is a series the exponent of the increment
-        series_start : float, optional
-            If it is a series, starting time
-        series_step : float, optional
-            If it is a series, step per element
-        series_unit : str, optional
-            If it is a series, units
+    applies_to_matrix_dimension : list of ints
+        Dimensions of this matrix that follow this mapping
+    indices_map_to_data_type : str one of CIFTI_MAP_TYPES
+        Type of mapping to the matrix indices
+    number_of_series_points : int, optional
+        If it is a series, number of points in the series
+    series_exponent : int, optional
+        If it is a series the exponent of the increment
+    series_start : float, optional
+        If it is a series, starting time
+    series_step : float, optional
+        If it is a series, step per element
+    series_unit : str, optional
+        If it is a series, units
     """
     _valid_type_mappings_ = {
         Cifti2BrainModel: ('CIFTI_INDEX_TYPE_BRAIN_MODELS',),
@@ -876,8 +1123,10 @@ class Cifti2Matrix(xml.XmlSerializable, collections.MutableSequence):
       values in the matrix.
     * Attributes: [NA]
     * Child Elements
-    * MetaData (0 .. 1)
-    * MatrixIndicesMap (1 .. N)
+
+        * MetaData (0 .. 1)
+        * MatrixIndicesMap (1 .. N)
+
     * Text Content: [NA]
     * Parent Element: CIFTI
 

--- a/nibabel/cifti2/cifti2.py
+++ b/nibabel/cifti2/cifti2.py
@@ -48,46 +48,48 @@ CIFTI_MAP_TYPES = ('CIFTI_INDEX_TYPE_BRAIN_MODELS',
                    'CIFTI_INDEX_TYPE_SCALARS',
                    'CIFTI_INDEX_TYPE_LABELS')
 
-CIFTI_MODEL_TYPES = ('CIFTI_MODEL_TYPE_SURFACE',
-                     'CIFTI_MODEL_TYPE_VOXELS')
+CIFTI_MODEL_TYPES = (
+    'CIFTI_MODEL_TYPE_SURFACE',  # Modeled using surface vertices
+    'CIFTI_MODEL_TYPE_VOXELS'    # Modeled using voxels.
+)
 
 CIFTI_SERIESUNIT_TYPES = ('SECOND',
                           'HERTZ',
                           'METER',
                           'RADIAN')
 
-CIFTI_BrainStructures = ('CIFTI_STRUCTURE_ACCUMBENS_LEFT',
-                         'CIFTI_STRUCTURE_ACCUMBENS_RIGHT',
-                         'CIFTI_STRUCTURE_ALL_WHITE_MATTER',
-                         'CIFTI_STRUCTURE_ALL_GREY_MATTER',
-                         'CIFTI_STRUCTURE_AMYGDALA_LEFT',
-                         'CIFTI_STRUCTURE_AMYGDALA_RIGHT',
-                         'CIFTI_STRUCTURE_BRAIN_STEM',
-                         'CIFTI_STRUCTURE_CAUDATE_LEFT',
-                         'CIFTI_STRUCTURE_CAUDATE_RIGHT',
-                         'CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_LEFT',
-                         'CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_RIGHT',
-                         'CIFTI_STRUCTURE_CEREBELLUM',
-                         'CIFTI_STRUCTURE_CEREBELLUM_LEFT',
-                         'CIFTI_STRUCTURE_CEREBELLUM_RIGHT',
-                         'CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_LEFT',
-                         'CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_RIGHT',
-                         'CIFTI_STRUCTURE_CORTEX',
-                         'CIFTI_STRUCTURE_CORTEX_LEFT',
-                         'CIFTI_STRUCTURE_CORTEX_RIGHT',
-                         'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT',
-                         'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT',
-                         'CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT',
-                         'CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT',
-                         'CIFTI_STRUCTURE_OTHER',
-                         'CIFTI_STRUCTURE_OTHER_GREY_MATTER',
-                         'CIFTI_STRUCTURE_OTHER_WHITE_MATTER',
-                         'CIFTI_STRUCTURE_PALLIDUM_LEFT',
-                         'CIFTI_STRUCTURE_PALLIDUM_RIGHT',
-                         'CIFTI_STRUCTURE_PUTAMEN_LEFT',
-                         'CIFTI_STRUCTURE_PUTAMEN_RIGHT',
-                         'CIFTI_STRUCTURE_THALAMUS_LEFT',
-                         'CIFTI_STRUCTURE_THALAMUS_RIGHT')
+CIFTI_BRAIN_STRUCTURES = ('CIFTI_STRUCTURE_ACCUMBENS_LEFT',
+                          'CIFTI_STRUCTURE_ACCUMBENS_RIGHT',
+                          'CIFTI_STRUCTURE_ALL_WHITE_MATTER',
+                          'CIFTI_STRUCTURE_ALL_GREY_MATTER',
+                          'CIFTI_STRUCTURE_AMYGDALA_LEFT',
+                          'CIFTI_STRUCTURE_AMYGDALA_RIGHT',
+                          'CIFTI_STRUCTURE_BRAIN_STEM',
+                          'CIFTI_STRUCTURE_CAUDATE_LEFT',
+                          'CIFTI_STRUCTURE_CAUDATE_RIGHT',
+                          'CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_LEFT',
+                          'CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_RIGHT',
+                          'CIFTI_STRUCTURE_CEREBELLUM',
+                          'CIFTI_STRUCTURE_CEREBELLUM_LEFT',
+                          'CIFTI_STRUCTURE_CEREBELLUM_RIGHT',
+                          'CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_LEFT',
+                          'CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_RIGHT',
+                          'CIFTI_STRUCTURE_CORTEX',
+                          'CIFTI_STRUCTURE_CORTEX_LEFT',
+                          'CIFTI_STRUCTURE_CORTEX_RIGHT',
+                          'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT',
+                          'CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT',
+                          'CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT',
+                          'CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT',
+                          'CIFTI_STRUCTURE_OTHER',
+                          'CIFTI_STRUCTURE_OTHER_GREY_MATTER',
+                          'CIFTI_STRUCTURE_OTHER_WHITE_MATTER',
+                          'CIFTI_STRUCTURE_PALLIDUM_LEFT',
+                          'CIFTI_STRUCTURE_PALLIDUM_RIGHT',
+                          'CIFTI_STRUCTURE_PUTAMEN_LEFT',
+                          'CIFTI_STRUCTURE_PUTAMEN_RIGHT',
+                          'CIFTI_STRUCTURE_THALAMUS_LEFT',
+                          'CIFTI_STRUCTURE_THALAMUS_RIGHT')
 
 
 def _value_if_klass(val, klass):
@@ -180,7 +182,10 @@ class Cifti2LabelTable(xml.XmlSerializable, collections.MutableMapping):
       LabelTable. Display coloring of continuous-valued data is not specified
       by CIFTI-2.
     * Attributes: [NA]
-    * Child Elements - Label (0...N)
+    * Child Elements
+
+        * Label (0...N)
+
     * Text Content: [NA]
     * Parent Element - NamedMap
     """
@@ -653,7 +658,7 @@ class Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ(xml.XmlSerializable):
     * Child Elements: [NA]
     * Text Content - Sixteen floating-point values, in row-major order, that
       form a 4x4 homogeneous transformation matrix.
-    *  Parent Element - Volume
+    * Parent Element - Volume
 
     Attributes
     ----------
@@ -793,7 +798,7 @@ class Cifti2BrainModel(xml.XmlSerializable):
         * IndexCount - Number of surface vertices or voxels in this brain
           model, must be positive.
         * ModelType - Type of model representing the brain structure (surface
-        * or voxels).  Valid values are listed in the table below.
+          or voxels).  Valid values are listed in the table below.
         * BrainStructure - Identifies the brain structure. Valid values for
           BrainStructure are listed in the table below. However, if the needed
           structure is not listed in the table, a message should be posted to
@@ -814,55 +819,9 @@ class Cifti2BrainModel(xml.XmlSerializable):
     * Text Content: [NA]
     * Parent Element - MatrixIndicesMap
 
-    ModelType Values
-    ----------------
+    For ModelType values, see CIFTI_MODEL_TYPES module attribute.
 
-    =========================  ================================
-    ModelType                  Description
-    =========================  ================================
-    CIFTI_MODEL_TYPE_SURFACE   Modeled using surface vertices.
-    CIFTI_MODEL_TYPE_VOXELS    Modeled using voxels.
-    =========================  ================================
-
-    BrainStructure Values
-    ---------------------
-
-    =============================================
-    BrainStructure
-    =============================================
-    CIFTI_STRUCTURE_ACCUMBENS_LEFT
-    CIFTI_STRUCTURE_ACCUMBENS_RIGHT
-    CIFTI_STRUCTURE_ALL_WHITE_MATTER
-    CIFTI_STRUCTURE_ALL_GREY_MATTER
-    CIFTI_STRUCTURE_AMYGDALA_LEFT
-    CIFTI_STRUCTURE_AMYGDALA_RIGHT
-    CIFTI_STRUCTURE_BRAIN_STEM
-    CIFTI_STRUCTURE_CAUDATE_LEFT
-    CIFTI_STRUCTURE_CAUDATE_RIGHT
-    CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_LEFT
-    CIFTI_STRUCTURE_CEREBELLAR_WHITE_MATTER_RIGHT
-    CIFTI_STRUCTURE_CEREBELLUM
-    CIFTI_STRUCTURE_CEREBELLUM_LEFT
-    CIFTI_STRUCTURE_CEREBELLUM_RIGHT
-    CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_LEFT
-    CIFTI_STRUCTURE_CEREBRAL_WHITE_MATTER_RIGHT
-    CIFTI_STRUCTURE_CORTEX
-    CIFTI_STRUCTURE_CORTEX_LEFT
-    CIFTI_STRUCTURE_CORTEX_RIGHT
-    CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT
-    CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT
-    CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT
-    CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT
-    CIFTI_STRUCTURE_OTHER
-    CIFTI_STRUCTURE_OTHER_GREY_MATTER
-    CIFTI_STRUCTURE_OTHER_WHITE_MATTER
-    CIFTI_STRUCTURE_PALLIDUM_LEFT
-    CIFTI_STRUCTURE_PALLIDUM_RIGHT
-    CIFTI_STRUCTURE_PUTAMEN_LEFT
-    CIFTI_STRUCTURE_PUTAMEN_RIGHT
-    CIFTI_STRUCTURE_THALAMUS_LEFT
-    CIFTI_STRUCTURE_THALAMUS_RIGHT
-    =============================================
+    For BrainStructure values, see CIFTI_BRAIN_STRUCTURES model attribute.
 
     Attributes
     ----------
@@ -873,7 +832,7 @@ class Cifti2BrainModel(xml.XmlSerializable):
     model_type : str
         One of CIFTI_MODEL_TYPES
     brain_structure : str
-        One of CIFTI_BrainStructures
+        One of CIFTI_BRAIN_STRUCTURES
     surface_number_of_vertices : int
         Number of vertices in the surface. Use only for surface-type structure
     voxel_indices_ijk : Cifti2VoxelIndicesIJK, optional

--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -17,7 +17,7 @@ from .cifti2 import (Cifti2MetaData, Cifti2Header, Cifti2Label,
                      Cifti2VoxelIndicesIJK, Cifti2BrainModel, Cifti2Matrix,
                      Cifti2MatrixIndicesMap, Cifti2NamedMap, Cifti2Parcel,
                      Cifti2Surface, Cifti2TransformationMatrixVoxelIndicesIJKtoXYZ,
-                     Cifti2Vertices, Cifti2Volume, CIFTI_BrainStructures,
+                     Cifti2Vertices, Cifti2Volume, CIFTI_BRAIN_STRUCTURES,
                      CIFTI_MODEL_TYPES, _underscore, CIFTI2HeaderError)
 from .. import xmlutils as xml
 from ..spatialimages import HeaderDataError
@@ -325,7 +325,7 @@ class Cifti2Parser(xml.XmlParser):
                     'Vertices element can only be a child of the CIFTI2 Parcel element'
                 )
             vertices.brain_structure = attrs["BrainStructure"]
-            if vertices.brain_structure not in CIFTI_BrainStructures:
+            if vertices.brain_structure not in CIFTI_BRAIN_STRUCTURES:
                 raise CIFTI2HeaderError(
                     'BrainStructure for this Vertices element is not valid'
                 )
@@ -391,7 +391,7 @@ class Cifti2Parser(xml.XmlParser):
                                ("SurfaceNumberOfVertices", int)]:
                 if key in attrs:
                     setattr(model, _underscore(key), dtype(attrs[key]))
-            if model.brain_structure not in CIFTI_BrainStructures:
+            if model.brain_structure not in CIFTI_BRAIN_STRUCTURES:
                 raise CIFTI2HeaderError(
                     'BrainStructure for this BrainModel element is not valid'
                 )

--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 import numpy as np
 
 from nibabel import cifti2 as ci
-from ...nifti1 import data_type_codes, intent_codes
+from nibabel.nifti1 import data_type_codes, intent_codes
+from nibabel.nifti2 import Nifti2Header
 
 from nibabel import cifti2 as ci
 from nibabel.cifti2.cifti2 import _float_01
@@ -298,3 +299,19 @@ def test_underscoring():
 
     for camel, underscored in pairs:
         assert_equal(ci.cifti2._underscore(camel), underscored)
+
+
+class TestCifti2ImageAPI(_TDA):
+    """ Basic validation for Cifti2Image instances
+    """
+    # A callable returning an image from ``image_maker(data, header)``
+    image_maker = ci.Cifti2Image
+    # A callable returning a header from ``header_maker()``
+    header_maker = ci.Cifti2Header
+    # A callable returning a nifti header
+    ni_header_maker = Nifti2Header
+    example_shapes = ((2,), (2, 3), (2, 3, 4))
+    standard_extension = '.nii'
+
+    def make_imaker(self, arr, header=None, ni_header=None):
+        return lambda: self.image_maker(arr.copy(), header, ni_header)

--- a/nibabel/cifti2/tests/test_cifti2.py
+++ b/nibabel/cifti2/tests/test_cifti2.py
@@ -16,6 +16,8 @@ from numpy.testing import (assert_array_almost_equal,
 
 from nose.tools import assert_true, assert_equal, assert_raises, assert_is_none
 
+from nibabel.tests.test_dataobj_images import TestDataobjAPI as _TDA
+
 
 def compare_xml_leaf(str1, str2):
     x1 = ElementTree.fromstring(str1)
@@ -112,6 +114,7 @@ def test_cifti2_labeltable():
     assert_raises(ValueError, lt.__setitem__, 0, ('foo', 1.1, 0, 0, 1))
     assert_raises(ValueError, lt.__setitem__, 0, ('foo', 1.0, -1, 0, 1))
     assert_raises(ValueError, lt.__setitem__, 0, ('foo', 1.0, 0, -0.1, 1))
+
 
 def test_cifti2_label():
     lb = ci.Cifti2Label()

--- a/nibabel/cifti2/tests/test_cifti2io.py
+++ b/nibabel/cifti2/tests/test_cifti2io.py
@@ -58,10 +58,17 @@ def test_read_internal():
 
 
 @needs_nibabel_data('nitest-cifti2')
-def test_read():
+def test_read_and_proxies():
     img2 = nib.load(DATA_FILE6)
     assert_true(isinstance(img2.header, ci.Cifti2Header))
     assert_equal(img2.shape, (1, 91282))
+    # While we cannot reshape arrayproxies, all images are in-memory
+    assert_true(img2.in_memory)
+    data = img2.get_data()
+    assert_true(data is img2.dataobj)
+    # Uncaching has no effect, images are always array images
+    img2.uncache()
+    assert_true(data is img2.get_data())
 
 
 @needs_nibabel_data('nitest-cifti2')
@@ -95,7 +102,7 @@ def test_readwritedata():
                     else:
                         assert_equal(len(map1.label_table),
                                      len(map2.label_table))
-            assert_array_almost_equal(img.data, img2.data)
+            assert_array_almost_equal(img.dataobj, img2.dataobj)
 
 
 @needs_nibabel_data('nitest-cifti2')
@@ -122,7 +129,7 @@ def test_nibabel_readwritedata():
                     else:
                         assert_equal(len(map1.label_table),
                                      len(map2.label_table))
-            assert_array_almost_equal(img.data, img2.data)
+            assert_array_almost_equal(img.dataobj, img2.dataobj)
 
 
 @needs_nibabel_data('nitest-cifti2')

--- a/nibabel/dataobj_images.py
+++ b/nibabel/dataobj_images.py
@@ -1,0 +1,242 @@
+""" File-based images that have data arrays
+
+The class:`DataObjImage` class defines an image that extends the
+:class:`FileBasedImage` by adding an array-like object, named ``dataobj``.
+This can either be an actual numpy array, or an object that:
+
+* returns an array from ``numpy.asanyarray(obj)``;
+* has an attribute or property ``shape``.
+"""
+
+import warnings
+
+import numpy as np
+
+from .filebasedimages import FileBasedImage
+
+
+class DataobjImage(FileBasedImage):
+    ''' Template class for images that have dataobj data stores'''
+
+    def __init__(self, dataobj, header=None, extra=None, file_map=None):
+        ''' Initialize dataobj image
+
+        The datobj image is a combination of (dataobj, header), with optional
+        metadata in `extra`, and filename / file-like objects contained in the
+        `file_map` mapping.
+
+        Parameters
+        ----------
+        dataobj : object
+           Object containg image data.  It should be some object that retuns an
+           array from ``np.asanyarray``.  It should have a ``shape`` attribute
+           or property
+        header : None or mapping or header instance, optional
+           metadata for this image format
+        extra : None or mapping, optional
+           metadata to associate with image that cannot be stored in the
+           metadata of this image type
+        file_map : mapping, optional
+           mapping giving file information for this image format
+        '''
+        super(DataobjImage, self).__init__(header=header, extra=extra,
+                                           file_map=file_map)
+        self._dataobj = dataobj
+        self._data_cache = None
+
+    @property
+    def dataobj(self):
+        return self._dataobj
+
+    @property
+    def _data(self):
+        warnings.warn('Please use ``dataobj`` instead of ``_data``; '
+                      'We will remove this wrapper for ``_data`` soon',
+                      FutureWarning,
+                      stacklevel=2)
+        return self._dataobj
+
+    def get_data(self, caching='fill'):
+        """ Return image data from image with any necessary scalng applied
+
+        The image ``dataobj`` property can be an array proxy or an array.  An
+        array proxy is an object that knows how to load the image data from
+        disk.  An image with an array proxy ``dataobj`` is a *proxy image*; an
+        image with an array in ``dataobj`` is an *array image*.
+
+        The default behavior for ``get_data()`` on a proxy image is to read the
+        data from the proxy, and store in an internal cache.  Future calls to
+        ``get_data`` will return the cached array.  This is the behavior
+        selected with `caching` == "fill".
+
+        Once the data has been cached and returned from an array proxy, if you
+        modify the returned array, you will also modify the cached array
+        (because they are the same array).  Regardless of the `caching` flag,
+        this is always true of an array image.
+
+        Parameters
+        ----------
+        caching : {'fill', 'unchanged'}, optional
+            See the Notes section for a detailed explanation.  This argument
+            specifies whether the image object should fill in an internal
+            cached reference to the returned image data array. "fill" specifies
+            that the image should fill an internal cached reference if
+            currently empty.  Future calls to ``get_data`` will return this
+            cached reference.  You might prefer "fill" to save the image object
+            from having to reload the array data from disk on each call to
+            ``get_data``.  "unchanged" means that the image should not fill in
+            the internal cached reference if the cache is currently empty.  You
+            might prefer "unchanged" to "fill" if you want to make sure that
+            the call to ``get_data`` does not create an extra (cached)
+            reference to the returned array.  In this case it is easier for
+            Python to free the memory from the returned array.
+
+        Returns
+        -------
+        data : array
+            array of image data
+
+        See also
+        --------
+        uncache: empty the array data cache
+
+        Notes
+        -----
+        All images have a property ``dataobj`` that represents the image array
+        data.  Images that have been loaded from files usually do not load the
+        array data from file immediately, in order to reduce image load time
+        and memory use.  For these images, ``dataobj`` is an *array proxy*; an
+        object that knows how to load the image array data from file.
+
+        By default (`caching` == "fill"), when you call ``get_data`` on a
+        proxy image, we load the array data from disk, store (cache) an
+        internal reference to this array data, and return the array.  The next
+        time you call ``get_data``, you will get the cached reference to the
+        array, so we don't have to load the array data from disk again.
+
+        Array images have a ``dataobj`` property that already refers to an
+        array in memory, so there is no benefit to caching, and the `caching`
+        keywords have no effect.
+
+        For proxy images, you may not want to fill the cache after reading the
+        data from disk because the cache will hold onto the array memory until
+        the image object is deleted, or you use the image ``uncache`` method.
+        If you don't want to fill the cache, then always use
+        ``get_data(caching='unchanged')``; in this case ``get_data`` will not
+        fill the cache (store the reference to the array) if the cache is empty
+        (no reference to the array).  If the cache is full, "unchanged" leaves
+        the cache full and returns the cached array reference.
+
+        The cache can effect the behavior of the image, because if the cache is
+        full, or you have an array image, then modifying the returned array
+        will modify the result of future calls to ``get_data()``.  For example
+        you might do this:
+
+        >>> import os
+        >>> import nibabel as nib
+        >>> from nibabel.testing import data_path
+        >>> img_fname = os.path.join(data_path, 'example4d.nii.gz')
+
+        >>> img = nib.load(img_fname) # This is a proxy image
+        >>> nib.is_proxy(img.dataobj)
+        True
+
+        The array is not yet cached by a call to "get_data", so:
+
+        >>> img.in_memory
+        False
+
+        After we call ``get_data`` using the default `caching` == 'fill', the
+        cache contains a reference to the returned array ``data``:
+
+        >>> data = img.get_data()
+        >>> img.in_memory
+        True
+
+        We modify an element in the returned data array:
+
+        >>> data[0, 0, 0, 0]
+        0
+        >>> data[0, 0, 0, 0] = 99
+        >>> data[0, 0, 0, 0]
+        99
+
+        The next time we call 'get_data', the method returns the cached
+        reference to the (modified) array:
+
+        >>> data_again = img.get_data()
+        >>> data_again is data
+        True
+        >>> data_again[0, 0, 0, 0]
+        99
+
+        If you had *initially* used `caching` == 'unchanged' then the returned
+        ``data`` array would have been loaded from file, but not cached, and:
+
+        >>> img = nib.load(img_fname)  # a proxy image again
+        >>> data = img.get_data(caching='unchanged')
+        >>> img.in_memory
+        False
+        >>> data[0, 0, 0] = 99
+        >>> data_again = img.get_data(caching='unchanged')
+        >>> data_again is data
+        False
+        >>> data_again[0, 0, 0, 0]
+        0
+        """
+        if caching not in ('fill', 'unchanged'):
+            raise ValueError('caching value should be "fill" or "unchanged"')
+        if self._data_cache is not None:
+            return self._data_cache
+        data = np.asanyarray(self._dataobj)
+        if caching == 'fill':
+            self._data_cache = data
+        return data
+
+    @property
+    def in_memory(self):
+        """ True when array data is in memory
+        """
+        return (isinstance(self._dataobj, np.ndarray) or
+                self._data_cache is not None)
+
+    def uncache(self):
+        """ Delete any cached read of data from proxied data
+
+        Remember there are two types of images:
+
+        * *array images* where the data ``img.dataobj`` is an array
+        * *proxy images* where the data ``img.dataobj`` is a proxy object
+
+        If you call ``img.get_data()`` on a proxy image, the result of reading
+        from the proxy gets cached inside the image object, and this cache is
+        what gets returned from the next call to ``img.get_data()``.  If you
+        modify the returned data, as in::
+
+            data = img.get_data()
+            data[:] = 42
+
+        then the next call to ``img.get_data()`` returns the modified array,
+        whether the image is an array image or a proxy image::
+
+            assert np.all(img.get_data() == 42)
+
+        When you uncache an array image, this has no effect on the return of
+        ``img.get_data()``, but when you uncache a proxy image, the result of
+        ``img.get_data()`` returns to its original value.
+        """
+        self._data_cache = None
+
+    @property
+    def shape(self):
+        return self._dataobj.shape
+
+    def get_shape(self):
+        """ Return shape for image
+
+        This function deprecated; please use the ``shape`` property instead
+        """
+        warnings.warn('Please use the shape property instead of get_shape',
+                      DeprecationWarning,
+                      stacklevel=2)
+        return self.shape

--- a/nibabel/filebasedimages.py
+++ b/nibabel/filebasedimages.py
@@ -9,6 +9,7 @@
 ''' Common interface for any image format--volume or surface, binary or xml.'''
 
 import warnings
+from copy import deepcopy
 
 from .externals.six import string_types
 from .fileholders import FileHolder
@@ -56,7 +57,7 @@ class FileBasedHeader(object):
         The copy should not be affected by any changes to the original
         object.
         '''
-        raise NotImplementedError
+        return deepcopy(self)
 
 
 class FileBasedImage(object):
@@ -190,11 +191,7 @@ class FileBasedImage(object):
         file_map : mapping, optional
            mapping giving file information for this image format
         '''
-
-        if header or self.header_class:
-            self._header = self.header_class.from_header(header)
-        else:
-            self._header = None
+        self._header = self.header_class.from_header(header)
         if extra is None:
             extra = {}
         self.extra = extra
@@ -235,10 +232,9 @@ class FileBasedImage(object):
         -------
         fname : None or str
            Returns None if there is no filename, or a filename string.
-           If an image may have several filenames assoctiated with it
-           (e.g Analyze ``.img, .hdr`` pair) then we return the more
-           characteristic filename (the ``.img`` filename in the case of
-           Analyze')
+           If an image may have several filenames associated with it (e.g.
+           Analyze ``.img, .hdr`` pair) then we return the more characteristic
+           filename (the ``.img`` filename in the case of Analyze')
         '''
         # which filename is returned depends on the ordering of the
         # 'files_types' class attribute - we return the name

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -137,7 +137,8 @@ import warnings
 
 import numpy as np
 
-from .filebasedimages import FileBasedHeader, FileBasedImage
+from .filebasedimages import FileBasedHeader
+from .dataobj_images import DataobjImage
 from .filebasedimages import ImageFileError  # flake8: noqa; for back-compat
 from .viewers import OrthoSlicer3D
 from .volumeutils import shape_zoom_affine
@@ -318,7 +319,7 @@ class ImageDataError(Exception):
     pass
 
 
-class SpatialImage(FileBasedImage):
+class SpatialImage(DataobjImage):
     ''' Template class for volumetric (3D/4D) images '''
     header_class = SpatialHeader
 
@@ -326,7 +327,7 @@ class SpatialImage(FileBasedImage):
                  extra=None, file_map=None):
         ''' Initialize image
 
-        The image is a combination of (array, affine matrix, header), with
+        The image is a combination of (array-like, affine matrix, header), with
         optional metadata in `extra`, and filename / file-like objects
         contained in the `file_map` mapping.
 
@@ -349,9 +350,8 @@ class SpatialImage(FileBasedImage):
         file_map : mapping, optional
            mapping giving file information for this image format
         '''
-        super(SpatialImage, self).__init__(header=header, extra=extra,
+        super(SpatialImage, self).__init__(dataobj, header=header, extra=extra,
                                            file_map=file_map)
-        self._dataobj = dataobj
         if not affine is None:
             # Check that affine is array-like 4,4.  Maybe this is too strict at
             # this abstract level, but so far I think all image formats we know
@@ -369,20 +369,7 @@ class SpatialImage(FileBasedImage):
                 self._header.set_data_dtype(dataobj.dtype)
         # make header correspond with image and affine
         self.update_header()
-        self._load_cache = None
         self._data_cache = None
-
-    @property
-    def _data(self):
-        warnings.warn('Please use ``dataobj`` instead of ``_data``; '
-                      'We will remove this wrapper for ``_data`` soon',
-                      FutureWarning,
-                      stacklevel=2)
-        return self._dataobj
-
-    @property
-    def dataobj(self):
-        return self._dataobj
 
     @property
     def affine(self):
@@ -410,7 +397,7 @@ class SpatialImage(FileBasedImage):
         if hdr.get_data_shape() != shape:
             hdr.set_data_shape(shape)
         # If the affine is not None, and it is different from the main affine
-        # in the header, update the heaader
+        # in the header, update the header
         if self._affine is None:
             return
         if np.allclose(self._affine, hdr.get_best_affine()):
@@ -436,191 +423,6 @@ class SpatialImage(FileBasedImage):
                           '%s' % affine,
                           'metadata:',
                           '%s' % self._header))
-
-    def get_data(self, caching='fill'):
-        """ Return image data from image with any necessary scalng applied
-
-        The image ``dataobj`` property can be an array proxy or an array.  An
-        array proxy is an object that knows how to load the image data from
-        disk.  An image with an array proxy ``dataobj`` is a *proxy image*; an
-        image with an array in ``dataobj`` is an *array image*.
-
-        The default behavior for ``get_data()`` on a proxy image is to read the
-        data from the proxy, and store in an internal cache.  Future calls to
-        ``get_data`` will return the cached array.  This is the behavior
-        selected with `caching` == "fill".
-
-        Once the data has been cached and returned from an array proxy, if you
-        modify the returned array, you will also modify the cached array
-        (because they are the same array).  Regardless of the `caching` flag,
-        this is always true of an array image.
-
-        Parameters
-        ----------
-        caching : {'fill', 'unchanged'}, optional
-            See the Notes section for a detailed explanation.  This argument
-            specifies whether the image object should fill in an internal
-            cached reference to the returned image data array. "fill" specifies
-            that the image should fill an internal cached reference if
-            currently empty.  Future calls to ``get_data`` will return this
-            cached reference.  You might prefer "fill" to save the image object
-            from having to reload the array data from disk on each call to
-            ``get_data``.  "unchanged" means that the image should not fill in
-            the internal cached reference if the cache is currently empty.  You
-            might prefer "unchanged" to "fill" if you want to make sure that
-            the call to ``get_data`` does not create an extra (cached)
-            reference to the returned array.  In this case it is easier for
-            Python to free the memory from the returned array.
-
-        Returns
-        -------
-        data : array
-            array of image data
-
-        See also
-        --------
-        uncache: empty the array data cache
-
-        Notes
-        -----
-        All images have a property ``dataobj`` that represents the image array
-        data.  Images that have been loaded from files usually do not load the
-        array data from file immediately, in order to reduce image load time
-        and memory use.  For these images, ``dataobj`` is an *array proxy*; an
-        object that knows how to load the image array data from file.
-
-        By default (`caching` == "fill"), when you call ``get_data`` on a
-        proxy image, we load the array data from disk, store (cache) an
-        internal reference to this array data, and return the array.  The next
-        time you call ``get_data``, you will get the cached reference to the
-        array, so we don't have to load the array data from disk again.
-
-        Array images have a ``dataobj`` property that already refers to an
-        array in memory, so there is no benefit to caching, and the `caching`
-        keywords have no effect.
-
-        For proxy images, you may not want to fill the cache after reading the
-        data from disk because the cache will hold onto the array memory until
-        the image object is deleted, or you use the image ``uncache`` method.
-        If you don't want to fill the cache, then always use
-        ``get_data(caching='unchanged')``; in this case ``get_data`` will not
-        fill the cache (store the reference to the array) if the cache is empty
-        (no reference to the array).  If the cache is full, "unchanged" leaves
-        the cache full and returns the cached array reference.
-
-        The cache can effect the behavior of the image, because if the cache is
-        full, or you have an array image, then modifying the returned array
-        will modify the result of future calls to ``get_data()``.  For example
-        you might do this:
-
-        >>> import os
-        >>> import nibabel as nib
-        >>> from nibabel.testing import data_path
-        >>> img_fname = os.path.join(data_path, 'example4d.nii.gz')
-
-        >>> img = nib.load(img_fname) # This is a proxy image
-        >>> nib.is_proxy(img.dataobj)
-        True
-
-        The array is not yet cached by a call to "get_data", so:
-
-        >>> img.in_memory
-        False
-
-        After we call ``get_data`` using the default `caching` == 'fill', the
-        cache contains a reference to the returned array ``data``:
-
-        >>> data = img.get_data()
-        >>> img.in_memory
-        True
-
-        We modify an element in the returned data array:
-
-        >>> data[0, 0, 0, 0]
-        0
-        >>> data[0, 0, 0, 0] = 99
-        >>> data[0, 0, 0, 0]
-        99
-
-        The next time we call 'get_data', the method returns the cached
-        reference to the (modified) array:
-
-        >>> data_again = img.get_data()
-        >>> data_again is data
-        True
-        >>> data_again[0, 0, 0, 0]
-        99
-
-        If you had *initially* used `caching` == 'unchanged' then the returned
-        ``data`` array would have been loaded from file, but not cached, and:
-
-        >>> img = nib.load(img_fname)  # a proxy image again
-        >>> data = img.get_data(caching='unchanged')
-        >>> img.in_memory
-        False
-        >>> data[0, 0, 0] = 99
-        >>> data_again = img.get_data(caching='unchanged')
-        >>> data_again is data
-        False
-        >>> data_again[0, 0, 0, 0]
-        0
-        """
-        if caching not in ('fill', 'unchanged'):
-            raise ValueError('caching value should be "fill" or "unchanged"')
-        if self._data_cache is not None:
-            return self._data_cache
-        data = np.asanyarray(self._dataobj)
-        if caching == 'fill':
-            self._data_cache = data
-        return data
-
-    @property
-    def in_memory(self):
-        """ True when array data is in memory
-        """
-        return (isinstance(self._dataobj, np.ndarray)
-                or self._data_cache is not None)
-
-    def uncache(self):
-        """ Delete any cached read of data from proxied data
-
-        Remember there are two types of images:
-
-        * *array images* where the data ``img.dataobj`` is an array
-        * *proxy images* where the data ``img.dataobj`` is a proxy object
-
-        If you call ``img.get_data()`` on a proxy image, the result of reading
-        from the proxy gets cached inside the image object, and this cache is
-        what gets returned from the next call to ``img.get_data()``.  If you
-        modify the returned data, as in::
-
-            data = img.get_data()
-            data[:] = 42
-
-        then the next call to ``img.get_data()`` returns the modified array,
-        whether the image is an array image or a proxy image::
-
-            assert np.all(img.get_data() == 42)
-
-        When you uncache an array image, this has no effect on the return of
-        ``img.get_data()``, but when you uncache a proxy image, the result of
-        ``img.get_data()`` returns to its original value.
-        """
-        self._data_cache = None
-
-    @property
-    def shape(self):
-        return self._dataobj.shape
-
-    def get_shape(self):
-        """ Return shape for image
-
-        This function deprecated; please use the ``shape`` property instead
-        """
-        warnings.warn('Please use the shape property instead of get_shape',
-                      DeprecationWarning,
-                      stacklevel=2)
-        return self.shape
 
     def get_data_dtype(self):
         return self._header.get_data_dtype()

--- a/nibabel/tests/test_dataobj_images.py
+++ b/nibabel/tests/test_dataobj_images.py
@@ -1,0 +1,40 @@
+""" Testing dataobj_images module
+"""
+
+import numpy as np
+
+from nibabel.filebasedimages import FileBasedHeader
+from nibabel.dataobj_images import DataobjImage
+
+from nibabel.tests.test_image_api import DataInterfaceMixin
+from nibabel.tests.test_filebasedimages import TestFBImageAPI as _TFI
+
+
+class DoNumpyImage(DataobjImage):
+    header_class = FileBasedHeader
+    valid_exts = ('.npy',)
+    files_types = (('image', '.npy'),)
+
+    @classmethod
+    def from_file_map(klass, file_map):
+        with file_map['image'].get_prepare_fileobj('rb') as fobj:
+            arr = np.load(fobj)
+        return klass(arr)
+
+    def to_file_map(self, file_map=None):
+        file_map = self.file_map if file_map is None else file_map
+        with file_map['image'].get_prepare_fileobj('wb') as fobj:
+            np.save(fobj, self.dataobj)
+
+    def get_data_dtype(self):
+        return self.dataobj.dtype
+
+    def set_data_dtype(self, dtype):
+        self._dataobj = self._dataobj.astype(dtype)
+
+
+class TestDataobjAPI(_TFI, DataInterfaceMixin):
+    """ Validation for DataobjImage instances
+    """
+    # A callable returning an image from ``image_maker(data, header)``
+    image_maker = DoNumpyImage

--- a/nibabel/tests/test_filebasedimages.py
+++ b/nibabel/tests/test_filebasedimages.py
@@ -60,15 +60,15 @@ class TestFBImageAPI(GenericImageAPI):
     can_save = True
     standard_extension = '.npy'
 
+    def make_imaker(self, arr, header=None):
+        return lambda: self.image_maker(arr, header)
+
     def obj_params(self):
         # Create new images
-        def make_imaker(arr, header=None):
-            return lambda: self.image_maker(arr, header)
-
         for shape, dtype in product(self.example_shapes, self.example_dtypes):
             arr = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
             hdr = self.header_maker()
-            func = make_imaker(arr.copy(), hdr)
+            func = self.make_imaker(arr.copy(), hdr)
             params = dict(
                 dtype=dtype,
                 data=arr,

--- a/nibabel/tests/test_filebasedimages.py
+++ b/nibabel/tests/test_filebasedimages.py
@@ -1,0 +1,74 @@
+""" Testing filebasedimages module
+"""
+
+from itertools import product
+
+import numpy as np
+
+from nibabel.filebasedimages import FileBasedHeader, FileBasedImage
+
+from nibabel.tests.test_image_api import GenericImageAPI
+
+
+class FBNumpyImage(FileBasedImage):
+    header_class = FileBasedHeader
+    valid_exts = ('.npy',)
+    files_types = (('image', '.npy'),)
+
+    def __init__(self, arr, header=None, extra=None, file_map=None):
+        super(FBNumpyImage, self).__init__(header, extra, file_map)
+        self.arr = arr
+
+    @property
+    def shape(self):
+        return self.arr.shape
+
+    def get_data(self):
+        return self.arr
+
+    @classmethod
+    def from_file_map(klass, file_map):
+        with file_map['image'].get_prepare_fileobj('rb') as fobj:
+            arr = np.load(fobj)
+        return klass(arr)
+
+    def to_file_map(self, file_map=None):
+        file_map = self.file_map if file_map is None else file_map
+        with file_map['image'].get_prepare_fileobj('wb') as fobj:
+            np.save(fobj, self.arr)
+
+    def get_data_dtype(self):
+        return self.arr.dtype
+
+    def set_data_dtype(self, dtype):
+        self.arr = self.arr.astype(dtype)
+
+
+class TestFBImageAPI(GenericImageAPI):
+    """ Validation for FileBasedImage instances
+    """
+    # A callable returning an image from ``image_maker(data, header)``
+    image_maker = FBNumpyImage
+    # A callable returning a header from ``header_maker()``
+    header_maker = FileBasedHeader
+    # Example shapes for created images
+    example_shapes = ((2,), (2, 3), (2, 3, 4), (2, 3, 4, 5))
+    example_dtypes = (np.int8, np.uint16, np.int32, np.float32)
+    can_save = True
+    standard_extension = '.npy'
+
+    def obj_params(self):
+        # Create new images
+        def make_imaker(arr, header=None):
+            return lambda: self.image_maker(arr, header)
+
+        for shape, dtype in product(self.example_shapes, self.example_dtypes):
+            arr = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+            hdr = self.header_maker()
+            func = make_imaker(arr.copy(), hdr)
+            params = dict(
+                dtype=dtype,
+                data=arr,
+                shape=shape,
+                is_proxy=False)
+            yield func, params

--- a/nibabel/tests/test_filebasedimages.py
+++ b/nibabel/tests/test_filebasedimages.py
@@ -9,6 +9,9 @@ from nibabel.filebasedimages import FileBasedHeader, FileBasedImage
 
 from nibabel.tests.test_image_api import GenericImageAPI
 
+from nose.tools import (assert_true, assert_false, assert_equal,
+                        assert_not_equal)
+
 
 class FBNumpyImage(FileBasedImage):
     header_class = FileBasedHeader
@@ -72,3 +75,35 @@ class TestFBImageAPI(GenericImageAPI):
                 shape=shape,
                 is_proxy=False)
             yield func, params
+
+
+def test_filebased_header():
+    # Test stuff about the default FileBasedHeader
+
+    class H(FileBasedHeader):
+
+        def __init__(self, seq=None):
+            if seq is None:
+                seq = []
+            self.a_list = list(seq)
+
+    in_list = [1, 3, 2]
+    hdr = H(in_list)
+    hdr_c = hdr.copy()
+    assert_equal(hdr_c.a_list, hdr.a_list)
+    # Copy is independent of original
+    hdr_c.a_list[0] = 99
+    assert_not_equal(hdr_c.a_list, hdr.a_list)
+    # From header does a copy
+    hdr2 = H.from_header(hdr)
+    assert_true(isinstance(hdr2, H))
+    assert_equal(hdr2.a_list, hdr.a_list)
+    hdr2.a_list[0] = 42
+    assert_not_equal(hdr2.a_list, hdr.a_list)
+    # Default header input to from_heder gives new empty header
+    hdr3 = H.from_header()
+    assert_true(isinstance(hdr3, H))
+    assert_equal(hdr3.a_list, [])
+    hdr4 = H.from_header(None)
+    assert_true(isinstance(hdr4, H))
+    assert_equal(hdr4.a_list, [])

--- a/nibabel/tests/test_image_api.py
+++ b/nibabel/tests/test_image_api.py
@@ -47,7 +47,8 @@ from ..testing import clear_and_catch_warnings
 from ..tmpdirs import InTemporaryDirectory
 
 from .test_api_validators import ValidateAPI
-from .test_helpers import bytesio_round_trip, assert_data_similar
+from .test_helpers import (bytesio_round_trip, bytesio_filemap,
+                           assert_data_similar)
 from .test_minc1 import EXAMPLE_IMAGES as MINC1_EXAMPLE_IMAGES
 from .test_minc2 import EXAMPLE_IMAGES as MINC2_EXAMPLE_IMAGES
 from .test_parrec import EXAMPLE_IMAGES as PARREC_EXAMPLE_IMAGES
@@ -100,35 +101,10 @@ class GenericImageAPI(ValidateAPI):
         """
         raise NotImplementedError
 
-    def validate_affine(self, imaker, params):
-        # Check affine API
-        img = imaker()
-        assert_almost_equal(img.affine, params['affine'], 6)
-        assert_equal(img.affine.dtype, np.float64)
-        img.affine[0, 0] = 1.5
-        assert_equal(img.affine[0, 0], 1.5)
-        # Read only
-        assert_raises(AttributeError, setattr, img, 'affine', np.eye(4))
-
-    def validate_affine_deprecated(self, imaker, params):
-        # Check deprecated affine API
-        img = imaker()
-        assert_almost_equal(img.get_affine(), params['affine'], 6)
-        assert_equal(img.get_affine().dtype, np.float64)
-        aff = img.get_affine()
-        aff[0, 0] = 1.5
-        assert_true(aff is img.get_affine())
-
     def validate_header(self, imaker, params):
         # Check header API
         img = imaker()
         hdr = img.header  # we can fetch it
-        # Change shape in header, check this changes img.header
-        shape = hdr.get_data_shape()
-        new_shape = (shape[0] + 1,) + shape[1:]
-        hdr.set_data_shape(new_shape)
-        assert_true(img.header is hdr)
-        assert_equal(img.header.get_data_shape(), new_shape)
         # Read only
         assert_raises(AttributeError, setattr, img, 'header', hdr)
 
@@ -149,9 +125,53 @@ class GenericImageAPI(ValidateAPI):
         # Same as array shape if passed
         if 'data' in params:
             assert_equal(img.shape, params['data'].shape)
-        assert_equal(img.shape, img.get_data().shape)
         # Read only
         assert_raises(AttributeError, setattr, img, 'shape', np.eye(4))
+
+    def validate_filenames(self, imaker, params):
+        # Validate the filename, file_map interface
+        if not self.can_save:
+            raise SkipTest
+        img = imaker()
+        img.set_data_dtype(np.float32)  # to avoid rounding in load / save
+        # Make sure the object does not have a file_map
+        img.file_map = None
+        # The bytesio_round_trip helper tests bytesio load / save via file_map
+        rt_img = bytesio_round_trip(img)
+        assert_array_equal(img.shape, rt_img.shape)
+        assert_almost_equal(img.get_data(), rt_img.get_data())
+        # Give the image a file map
+        klass = type(img)
+        rt_img.file_map = bytesio_filemap(klass)
+        # This object can now be saved and loaded from its own file_map
+        rt_img.to_file_map()
+        rt_rt_img = klass.from_file_map(rt_img.file_map)
+        assert_almost_equal(img.get_data(), rt_rt_img.get_data())
+        # get_ / set_ filename
+        fname = 'an_image' + self.standard_extension
+        img.set_filename(fname)
+        assert_equal(img.get_filename(), fname)
+        assert_equal(img.file_map['image'].filename, fname)
+        # to_ / from_ filename
+        fname = 'another_image' + self.standard_extension
+        with InTemporaryDirectory():
+            img.to_filename(fname)
+            rt_img = img.__class__.from_filename(fname)
+            assert_array_equal(img.shape, rt_img.shape)
+            assert_almost_equal(img.get_data(), rt_img.get_data())
+            del rt_img  # to allow windows to delete the directory
+
+    def validate_no_slicing(self, imaker, params):
+        img = imaker()
+        assert_raises(TypeError, img.__getitem__, 'string')
+        assert_raises(TypeError, img.__getitem__, slice(None))
+
+
+class GetSetDtypeMixin(object):
+    """ Adds dtype tests
+
+    Add this one if your image has ``get_data_dtype`` and ``set_data_dtype``.
+    """
 
     def validate_dtype(self, imaker, params):
         # data / storage dtype
@@ -171,9 +191,17 @@ class GenericImageAPI(ValidateAPI):
             rt_img = bytesio_round_trip(img)
             assert_equal(rt_img.get_data_dtype().type, np.float32)
 
-    def validate_data(self, imaker, params):
+
+class DataInterfaceMixin(GetSetDtypeMixin):
+    """ Test dataobj interface for images with array backing
+
+    Use this mixin if your image has a ``dataobj`` property that contains an
+    array or an array-like thing.
+    """
+    def validate_data_interface(self, imaker, params):
         # Check get data returns array, and caches
         img = imaker()
+        assert_equal(img.shape, img.dataobj.shape)
         assert_data_similar(img.dataobj, params)
         if params['is_proxy']:
             assert_false(isinstance(img.dataobj, np.ndarray))
@@ -232,6 +260,8 @@ class GenericImageAPI(ValidateAPI):
                 img.uncache()
                 assert_array_equal(get_data_func(), 42)
                 assert_true(img.in_memory)
+        # Data shape is same as image shape
+        assert_equal(img.shape, img.get_data().shape)
         # dataobj is read only
         fake_data = np.zeros(img.shape).astype(img.get_data_dtype())
         assert_raises(AttributeError, setattr, img, 'dataobj', fake_data)
@@ -251,37 +281,57 @@ class GenericImageAPI(ValidateAPI):
         fake_data = np.zeros(img.shape).astype(img.get_data_dtype())
         assert_raises(AttributeError, setattr, img, '_data', fake_data)
 
-    def validate_filenames(self, imaker, params):
-        # Validate the filename, file_map interface
-        if not self.can_save:
-            raise SkipTest
+
+class HeaderShapeMixin(object):
+    """ Tests that header shape can be set and got
+
+    Add this one of your header supports ``get_data_shape`` and
+    ``set_data_shape``.
+    """
+
+    def validate_header_shape(self, imaker, params):
+        # Change shape in header, check this changes img.header
         img = imaker()
-        img.set_data_dtype(np.float32)  # to avoid rounding in load / save
-        # The bytesio_round_trip helper tests bytesio load / save via file_map
-        rt_img = bytesio_round_trip(img)
-        assert_array_equal(img.shape, rt_img.shape)
-        assert_almost_equal(img.get_data(), rt_img.get_data())
-        # get_ / set_ filename
-        fname = 'an_image' + self.standard_extension
-        img.set_filename(fname)
-        assert_equal(img.get_filename(), fname)
-        assert_equal(img.file_map['image'].filename, fname)
-        # to_ / from_ filename
-        fname = 'another_image' + self.standard_extension
-        with InTemporaryDirectory():
-            img.to_filename(fname)
-            rt_img = img.__class__.from_filename(fname)
-            assert_array_equal(img.shape, rt_img.shape)
-            assert_almost_equal(img.get_data(), rt_img.get_data())
-            del rt_img  # to allow windows to delete the directory
+        hdr = img.header
+        shape = hdr.get_data_shape()
+        new_shape = (shape[0] + 1,) + shape[1:]
+        hdr.set_data_shape(new_shape)
+        assert_true(img.header is hdr)
+        assert_equal(img.header.get_data_shape(), new_shape)
 
-    def validate_no_slicing(self, imaker, params):
+
+class AffineMixin(object):
+    """ Adds test of affine property, method
+
+    Add this one if your image has an ``affine`` property.  If so, it should
+    (for now) also have a ``get_affine`` method returning the same result.
+    """
+
+    def validate_affine(self, imaker, params):
+        # Check affine API
         img = imaker()
-        assert_raises(TypeError, img.__getitem__, 'string')
-        assert_raises(TypeError, img.__getitem__, slice(None))
+        assert_almost_equal(img.affine, params['affine'], 6)
+        assert_equal(img.affine.dtype, np.float64)
+        img.affine[0, 0] = 1.5
+        assert_equal(img.affine[0, 0], 1.5)
+        # Read only
+        assert_raises(AttributeError, setattr, img, 'affine', np.eye(4))
+
+    def validate_affine_deprecated(self, imaker, params):
+        # Check deprecated affine API
+        img = imaker()
+        assert_almost_equal(img.get_affine(), params['affine'], 6)
+        assert_equal(img.get_affine().dtype, np.float64)
+        aff = img.get_affine()
+        aff[0, 0] = 1.5
+        assert_true(aff is img.get_affine())
 
 
-class LoadImageAPI(GenericImageAPI):
+class LoadImageAPI(GenericImageAPI,
+                   DataInterfaceMixin,
+                   AffineMixin,
+                   GetSetDtypeMixin,
+                   HeaderShapeMixin):
     # Callable returning an image from a filename
     loader = None
     # Sequence of dictionaries, where dictionaries have keys
@@ -312,9 +362,6 @@ class MakeImageAPI(LoadImageAPI):
     header_maker = None
     # Example shapes for created images
     example_shapes = ((2,), (2, 3), (2, 3, 4), (2, 3, 4, 5))
-
-    def img_from_arr_aff(self, arr, aff, header=None):
-        return self.image_maker(arr, aff, header)
 
     def obj_params(self):
         # Return any obj_params from superclass


### PR DESCRIPTION
This PR gets Cifti2 ready for using array proxies instead of always needing to
load the data arrays into memory.

First I made a helper function to use the ArrayProxy reshape method to reshape,
where possible, expecting to get this implemented soon.

Next I refactored the Image object API tests to be more flexible in the range of features the image type allows, ready for testing the new DataobjImage type.

Then I split the API features using the `dataobj` attribute from `SpatialImage` to a custom class, inheriting from `FileBasedImage`.    The new Image API tests can now cover testing for the new class and the old `FileBasedImage` class.

Finally, I refactored the API of `Cifti2Image` to use a more standard interface.   That refactoring still needs some tests, because we can't yet create a writeable default `Cifti2Header` (see question on conversation thread for pr/249).
