### PR TITLE
additional tests covering the various CIFTI file types

### DIFF
--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -547,7 +547,7 @@ class Cifti2Parser(xml.XmlParser):
             # conversion to numpy array
             c = BytesIO(data.strip().encode('utf-8'))
             parent = self.struct_state[-1]
-            parent.voxel_indices_ijk.extend(np.genfromtxt(c, dtype=np.int))
+            parent.voxel_indices_ijk.extend(np.genfromtxt(c, dtype=np.int).reshape(-1, 3))
             c.close()
 
         elif self.write_to == 'VertexIndices':

--- a/nibabel/cifti2/parse_cifti2.py
+++ b/nibabel/cifti2/parse_cifti2.py
@@ -566,7 +566,7 @@ class Cifti2Parser(xml.XmlParser):
 
         elif self.write_to == 'Label':
             label = self.struct_state[-1]
-            label.label = data.strip().encode('utf-8')
+            label.label = data.strip()
 
         elif self.write_to == 'MapName':
             named_map = self.struct_state[-1]

--- a/nibabel/cifti2/tests/test_cifti2io.py
+++ b/nibabel/cifti2/tests/test_cifti2io.py
@@ -208,6 +208,207 @@ def test_cifti2types():
         assert_true(count > 0, "No exercise of " + klass.__name__)
 
 
+@needs_nibabel_data('nitest-cifti2')
+def test_read_geometry():
+    img = ci.Cifti2Image.from_filename(DATA_FILE6)
+    geometry_mapping = img.header.matrix.get_index_map(1)
+
+    # For every brain model in ones.dscalar.nii defines:
+    # brain structure name, number of grayordinates, first vertex or voxel, last vertex or voxel
+    expected_geometry = [('CIFTI_STRUCTURE_CORTEX_LEFT', 29696, 0, 32491),
+                         ('CIFTI_STRUCTURE_CORTEX_RIGHT', 29716, 0, 32491),
+                         ('CIFTI_STRUCTURE_ACCUMBENS_LEFT', 135, [49, 66, 28], [48, 72, 35]),
+                         ('CIFTI_STRUCTURE_ACCUMBENS_RIGHT', 140, [40, 66, 29], [43, 66, 36]),
+                         ('CIFTI_STRUCTURE_AMYGDALA_LEFT', 315, [55, 61, 21], [56, 58, 31]),
+                         ('CIFTI_STRUCTURE_AMYGDALA_RIGHT', 332, [34, 62, 20], [36, 61, 31]),
+                         ('CIFTI_STRUCTURE_BRAIN_STEM', 3472, [42, 41, 0], [46, 50, 36]),
+                         ('CIFTI_STRUCTURE_CAUDATE_LEFT', 728, [50, 72, 32], [53, 60, 49]),
+                         ('CIFTI_STRUCTURE_CAUDATE_RIGHT', 755, [40, 68, 33], [37, 62, 49]),
+                         ('CIFTI_STRUCTURE_CEREBELLUM_LEFT', 8709, [49, 35, 4], [46, 37, 37]),
+                         ('CIFTI_STRUCTURE_CEREBELLUM_RIGHT', 9144, [38, 35, 4], [44, 38, 36]),
+                         ('CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_LEFT', 706, [52, 53, 26], [56, 49, 35]),
+                         ('CIFTI_STRUCTURE_DIENCEPHALON_VENTRAL_RIGHT', 712, [39, 54, 26], [35, 49, 36]),
+                         ('CIFTI_STRUCTURE_HIPPOCAMPUS_LEFT', 764, [55, 60, 21], [54, 44, 39]),
+                         ('CIFTI_STRUCTURE_HIPPOCAMPUS_RIGHT', 795, [33, 60, 21], [38, 45, 39]),
+                         ('CIFTI_STRUCTURE_PALLIDUM_LEFT', 297, [56, 59, 32], [55, 61, 39]),
+                         ('CIFTI_STRUCTURE_PALLIDUM_RIGHT', 260, [36, 62, 32], [35, 62, 39]),
+                         ('CIFTI_STRUCTURE_PUTAMEN_LEFT', 1060, [51, 66, 28], [58, 64, 43]),
+                         ('CIFTI_STRUCTURE_PUTAMEN_RIGHT', 1010, [34, 66, 29], [31, 62, 43]),
+                         ('CIFTI_STRUCTURE_THALAMUS_LEFT', 1288, [55, 47, 33], [52, 53, 46]),
+                         ('CIFTI_STRUCTURE_THALAMUS_RIGHT', 1248, [32, 47, 34], [38, 55, 46])]
+    current_index = 0
+    for from_file, expected in zip(geometry_mapping.brain_models, expected_geometry):
+        assert_true(from_file.model_type in ("CIFTI_MODEL_TYPE_SURFACE", "CIFTI_MODEL_TYPE_VOXELS"))
+        assert_equal(from_file.brain_structure, expected[0])
+        assert_equal(from_file.index_offset, current_index)
+        assert_equal(from_file.index_count, expected[1])
+        current_index += from_file.index_count
+
+        if from_file.model_type == 'CIFTI_MODEL_TYPE_SURFACE':
+            assert_equal(from_file.voxel_indices_ijk, None)
+            assert_equal(len(from_file.vertex_indices), expected[1])
+            assert_equal(from_file.vertex_indices[0], expected[2])
+            assert_equal(from_file.vertex_indices[-1], expected[3])
+            assert_equal(from_file.surface_number_of_vertices, 32492)
+        else:
+            assert_equal(from_file.vertex_indices, None)
+            assert_equal(from_file.surface_number_of_vertices, None)
+            assert_equal(len(from_file.voxel_indices_ijk), expected[1])
+            assert_equal(from_file.voxel_indices_ijk[0], expected[2])
+            assert_equal(from_file.voxel_indices_ijk[-1], expected[3])
+    assert_equal(current_index, img.shape[1])
+
+    expected_affine = [[-2, 0, 0,   90],
+                       [ 0, 2, 0, -126],
+                       [ 0, 0, 2,  -72],
+                       [ 0, 0, 0,    1]]
+    expected_dimensions = (91, 109, 91)
+    assert_true((geometry_mapping.volume.transformation_matrix_voxel_indices_ijk_to_xyz.matrix ==
+                 expected_affine).all())
+    assert_equal(geometry_mapping.volume.volume_dimensions, expected_dimensions)
+
+
+@needs_nibabel_data('nitest-cifti2')
+def test_read_parcels():
+    img = ci.Cifti2Image.from_filename(DATA_FILE4)
+    parcel_mapping = img.header.matrix.get_index_map(1)
+
+    expected_parcels = [('MEDIAL.WALL', ((719, 20, 28550), (810, 21, 28631))),
+                        ('BA2_FRB08', ((516, 6757, 17888), (461, 6757, 17887))),
+                        ('BA1_FRB08', ((211, 5029, 17974), (214, 3433, 17934))),
+                        ('BA3b_FRB08', ((444, 3436, 18065), (397, 3436, 18065))),
+                        ('BA4p_FRB08', ((344, 3445, 18164), (371, 3443, 18175))),
+                        ('BA3a_FRB08', ((290, 3441, 18140), (289, 3440, 18140))),
+                        ('BA4a_FRB08', ((471, 3446, 18181), (455, 3446, 19759))),
+                        ('BA6_FRB08', ((1457, 2, 30951), (1400, 2, 30951))),
+                        ('BA17_V1_FRB08', ((629, 23155, 25785), (635, 23155, 25759))),
+                        ('BA45_FRB08', ((245, 10100, 18774), (214, 10103, 18907))),
+                        ('BA44_FRB08', ((226, 10118, 19240), (273, 10119, 19270))),
+                        ('hOc5_MT_FRB08', ((104, 15019, 23329), (80, 15023, 23376))),
+                        ('BA18_V2_FRB08', ((702, 95, 25902), (651, 98, 25903))),
+                        ('V3A_SHM07', ((82, 4, 25050), (82, 4, 25050))),
+                        ('V3B_SHM07', ((121, 13398, 23303), (121, 13398, 23303))),
+                        ('LO1_KPO10', ((54, 15007, 23543), (54, 15007, 23543))),
+                        ('LO2_KPO10', ((79, 15013, 23636), (79, 15013, 23636))),
+                        ('PITd_KPO10', ((53, 15018, 23769), (65, 15018, 23769))),
+                        ('PITv_KPO10', ((72, 23480, 23974), (72, 23480, 23974))),
+                        ('OP1_BSW08', ((470, 8421, 18790), (470, 8421, 18790))),
+                        ('OP2_BSW08', ((67, 10, 31060), (67, 10, 31060))),
+                        ('OP3_BSW08', ((119, 10137, 18652), (119, 10137, 18652))),
+                        ('OP4_BSW08', ((191, 16613, 19429), (192, 16613, 19429))),
+                        ('IPS1_SHM07', ((54, 11775, 14496), (54, 11775, 14496))),
+                        ('IPS2_SHM07', ((71, 11771, 14587), (71, 11771, 14587))),
+                        ('IPS3_SHM07', ((114, 11764, 14783), (114, 11764, 14783))),
+                        ('IPS4_SHM07', ((101, 11891, 12653), (101, 11891, 12653))),
+                        ('V7_SHM07', ((140, 11779, 14002), (140, 11779, 14002))),
+                        ('V4v_SHM07', ((81, 23815, 24557), (90, 23815, 24557))),
+                        ('V3d_KPO10', ((90, 23143, 25192), (115, 23143, 25192))),
+                        ('14c_OFP03', ((22, 19851, 21311), (22, 19851, 21311))),
+                        ('13a_OFP03', ((20, 20963, 21154), (20, 20963, 21154))),
+                        ('47s_OFP03', ((211, 10182, 20343), (211, 10182, 20343))),
+                        ('14r_OFP03', ((54, 21187, 21324), (54, 21187, 21324))),
+                        ('13m_OFP03', ((103, 20721, 21075), (103, 20721, 21075))),
+                        ('13l_OFP03', ((101, 20466, 20789), (101, 20466, 20789))),
+                        ('32pl_OFP03', ((14, 19847, 21409), (14, 19847, 21409))),
+                        ('25_OFP03', ((8, 19844, 27750), (8, 19844, 27750))),
+                        ('47m_OFP03', ((200, 10174, 20522), (200, 10174, 20522))),
+                        ('47l_OFP03', ((142, 10164, 19969), (160, 10164, 19969))),
+                        ('Iai_OFP03', ((153, 10188, 20199), (153, 10188, 20199))),
+                        ('10r_OFP03', ((138, 19811, 28267), (138, 19811, 28267))),
+                        ('11m_OFP03', ((92, 20850, 21165), (92, 20850, 21165))),
+                        ('11l_OFP03', ((200, 20275, 21029), (200, 20275, 21029))),
+                        ('47r_OFP03', ((259, 10094, 20535), (259, 10094, 20535))),
+                        ('10m_OFP03', ((102, 19825, 21411), (102, 19825, 21411))),
+                        ('Iam_OFP03', ((15, 20346, 20608), (15, 20346, 20608))),
+                        ('Ial_OFP03', ((89, 10194, 11128), (89, 10194, 11128))),
+                        ('24_OFP03', ((39, 19830, 28279), (36, 19830, 28279))),
+                        ('Iapm_OFP03', ((7, 20200, 20299), (7, 20200, 20299))),
+                        ('10p_OFP03', ((480, 19780, 28640), (480, 19780, 28640))),
+                        ('V6_PHG06', ((72, 12233, 12869), (72, 12233, 12869))),
+                        ('ER_FRB08', ((103, 21514, 26470), (103, 21514, 26470))),
+                        ('13b_OFP03', ((60, 21042, 21194), (71, 21040, 21216)))]
+
+    assert_equal(img.shape[1], len(expected_parcels))
+    assert_equal(len(list(parcel_mapping.parcels)), len(expected_parcels))
+
+    for (name, expected_surfaces), parcel in zip(expected_parcels, parcel_mapping.parcels):
+        assert_equal(parcel.name, name)
+        assert_equal(len(parcel.vertices), 2)
+        for vertices, orientation, (length, first_element, last_element) in zip(parcel.vertices, ('LEFT', 'RIGHT'),
+                                                                                expected_surfaces):
+            assert_equal(len(vertices), length)
+            assert_equal(vertices[0], first_element)
+            assert_equal(vertices[-1], last_element)
+            assert_equal(vertices.brain_structure, 'CIFTI_STRUCTURE_CORTEX_%s' % orientation)
+
+
+@needs_nibabel_data('nitest-cifti2')
+def test_read_scalar():
+    img = ci.Cifti2Image.from_filename(DATA_FILE2)
+    scalar_mapping = img.header.matrix.get_index_map(0)
+
+    expected_names = ('MyelinMap_BC_decurv', 'corrThickness')
+    assert_equal(img.shape[0], len(expected_names))
+    assert_equal(len(list(scalar_mapping.named_maps)), len(expected_names))
+
+    expected_meta = [('PaletteColorMapping', '<PaletteColorMapping Version="1">\n   <ScaleMo')]
+    for scalar, name in zip(scalar_mapping.named_maps, expected_names):
+        assert_equal(scalar.map_name, name)
+
+        assert_equal(len(scalar.metadata), len(expected_meta))
+        print(expected_meta[0], scalar.metadata.data.keys())
+        for key, value in expected_meta:
+            assert_true(key in scalar.metadata.data.keys())
+            assert_equal(scalar.metadata[key][:len(value)], value)
+
+        assert_equal(scalar.label_table, None, ".dscalar file should not define a label table")
+
+
+@needs_nibabel_data('nitest-cifti2')
+def test_read_series():
+    img = ci.Cifti2Image.from_filename(DATA_FILE4)
+    series_mapping = img.header.matrix.get_index_map(0)
+    assert_equal(series_mapping.series_start, 0.)
+    assert_equal(series_mapping.series_step, 1.)
+    assert_equal(series_mapping.series_unit, 'SECOND')
+    assert_equal(series_mapping.series_exponent, 0.)
+    assert_equal(series_mapping.number_of_series_points, img.shape[0])
+
+
+@needs_nibabel_data('nitest-cifti2')
+def test_read_labels():
+    img = ci.Cifti2Image.from_filename(DATA_FILE5)
+    label_mapping = img.header.matrix.get_index_map(0)
+
+    expected_names = ['Composite Parcellation-lh (FRB08_OFP03_retinotopic)',
+                      'Brodmann lh (from colin.R via pals_R-to-fs_LR)',
+                      'MEDIAL WALL lh (fs_LR)']
+    assert_equal(img.shape[0], len(expected_names))
+    assert_equal(len(list(label_mapping.named_maps)), len(expected_names))
+
+    some_expected_labels = {0: ('???', (0.667, 0.667, 0.667, 0.0)),
+                            1: ('MEDIAL.WALL', (0.075, 0.075, 0.075, 1.0)),
+                            2: ('BA2_FRB08', (0.467, 0.459, 0.055, 1.0)),
+                            3: ('BA1_FRB08', (0.475, 0.722, 0.859, 1.0)),
+                            4: ('BA3b_FRB08', (0.855, 0.902, 0.286, 1.0)),
+                            5: ('BA4p_FRB08', (0.902, 0.573, 0.122, 1.0)),
+                            89: ('36_B05', (0.467, 0.0, 0.129, 1.0)),
+                            90: ('35_B05', (0.467, 0.067, 0.067, 1.0)),
+                            91: ('28_B05', (0.467, 0.337, 0.271, 1.0)),
+                            92: ('29_B05', (0.267, 0.0, 0.529, 1.0)),
+                            93: ('26_B05', (0.757, 0.2, 0.227, 1.0)),
+                            94: ('33_B05', (0.239, 0.082, 0.373, 1.0)),
+                            95: ('13b_OFP03', (1.0, 1.0, 0.0, 1.0))}
+
+    for named_map, name in zip(label_mapping.named_maps, expected_names):
+        assert_equal(named_map.map_name, name)
+        assert_equal(len(named_map.metadata), 0)
+        assert_equal(len(named_map.label_table), 96)
+        for index, (label, rgba) in some_expected_labels.items():
+            assert_equal(named_map.label_table[index].label, label)
+            assert_equal(named_map.label_table[index].rgba, rgba)
+
+
 class TestCifti2SingleHeader(TestNifti2SingleHeader):
     header_class = _Cifti2AsNiftiHeader
     _pixdim_message = 'pixdim[1,2,3] should be zero or positive'

--- a/nibabel/cifti2/tests/test_new_cifti2.py
+++ b/nibabel/cifti2/tests/test_new_cifti2.py
@@ -1,0 +1,385 @@
+"""Tests the generation of new CIFTI2 files from scratch
+
+Contains a series of functions to create and check each of the 5 CIFTI index types
+(i.e. BRAIN_MODELS, PARCELS, SCALARS, LABELS, and SERIES).
+
+These functions are used in the tests to generate most CIFTI file types from scratch.
+"""
+import numpy as np
+
+from nibabel import cifti2 as ci
+from nibabel.tmpdirs import InTemporaryDirectory
+
+from nose.tools import assert_true, assert_equal
+
+affine = [[-1.5, 0, 0, 90],
+          [0, 1.5, 0, -85],
+          [0, 0, 1.5, -71]]
+
+dimensions = (120, 83, 78)
+
+number_of_vertices = 30000
+
+brain_models = [('CIFTI_STRUCTURE_THALAMUS_LEFT', [[60, 60, 60],
+                                                   [61, 59, 60],
+                                                   [61, 60, 59],
+                                                   [80, 90, 92]]),
+                ('CIFTI_STRUCTURE_CORTEX_LEFT', [0, 1000, 1301, 19972, 27312])]
+
+
+def create_geometry_map(applies_to_matrix_dimension):
+    voxels = ci.Cifti2VoxelIndicesIJK(brain_models[0][1])
+    left_thalamus= ci.Cifti2BrainModel(index_offset=0, index_count=4, model_type='CIFTI_MODEL_TYPE_VOXELS',
+                                       brain_structure=brain_models[0][0], voxel_indices_ijk=voxels)
+    vertices = ci.Cifti2VertexIndices(np.array(brain_models[1][1]))
+    left_cortex = ci.Cifti2BrainModel(index_offset=4, index_count=5, model_type='CIFTI_MODEL_TYPE_SURFACE',
+                                      brain_structure=brain_models[1][0], vertex_indices=vertices)
+    return ci.Cifti2MatrixIndicesMap(applies_to_matrix_dimension, 'CIFTI_INDEX_TYPE_BRAIN_MODELS',
+                                     maps=[left_thalamus, left_cortex])
+
+
+def check_geometry_map(mapping):
+    assert_equal(mapping.indices_map_to_data_type, 'CIFTI_INDEX_TYPE_BRAIN_MODELS')
+    assert_equal(len(list(mapping.brain_models)), 2)
+    left_thalamus, left_cortex = mapping.brain_models
+
+    assert_equal(left_thalamus.index_offset, 0)
+    assert_equal(left_thalamus.index_count, 4)
+    assert_equal(left_thalamus.model_type, 'CIFTI_MODEL_TYPE_VOXELS')
+    assert_equal(left_thalamus.brain_structure, brain_models[0][0])
+    assert_equal(left_thalamus.vertex_indices, None)
+    assert_equal(left_thalamus.voxel_indices_ijk._indices, brain_models[0][1])
+
+    assert_equal(left_cortex.index_offset, 4)
+    assert_equal(left_cortex.index_count, 5)
+    assert_equal(left_cortex.model_type, 'CIFTI_MODEL_TYPE_SURFACE')
+    assert_equal(left_cortex.brain_structure, brain_models[1][0])
+    assert_equal(left_cortex.voxel_indices_ijk, None)
+    assert_equal(left_cortex.vertex_indices._indices, brain_models[1][1])
+
+
+parcels = [('volume_parcel', ([[60, 60, 60],
+                               [61, 59, 60],
+                               [61, 60, 59],
+                               [80, 90, 92]], )),
+           ('surface_parcel', (('CIFTI_STRUCTURE_CORTEX_LEFT', [0, 1000, 1301, 19972, 27312]),
+                               ('CIFTI_STRUCTURE_CORTEX_RIGHT', [0, 100, 381]))),
+           ('mixed_parcel', ([[71, 81, 39],
+                              [53, 21, 91]],
+                             ('CIFTI_STRUCTURE_CORTEX_LEFT', [71, 88, 999])))]
+
+
+def create_parcel_map(applies_to_matrix_dimension):
+    mapping = ci.Cifti2MatrixIndicesMap(applies_to_matrix_dimension, 'CIFTI_INDEX_TYPE_PARCELS')
+    for name, elements in parcels:
+        surfaces = []
+        volume = None
+        for element in elements:
+            if isinstance(element[0], str):
+                surfaces.append(ci.Cifti2Vertices(element[0], element[1]))
+            else:
+                volume = ci.Cifti2VoxelIndicesIJK(element)
+        mapping.append(ci.Cifti2Parcel(name, volume, surfaces))
+    return mapping
+
+
+def check_parcel_map(mapping):
+    assert_equal(mapping.indices_map_to_data_type, 'CIFTI_INDEX_TYPE_PARCELS')
+    assert_equal(len(list(mapping.parcels)), 3)
+    for (name, elements), parcel in zip(parcels, mapping.parcels):
+        assert_equal(parcel.name, name)
+        idx_surface = 0
+        for element in elements:
+            if isinstance(element[0], str):
+                surface = parcel.vertices[idx_surface]
+                assert_equal(surface.brain_structure, element[0])
+                assert_equal(surface._vertices, element[1])
+                idx_surface += 1
+            else:
+                assert_equal(parcel.voxel_indices_ijk._indices, element)
+
+scalars = [('first_name', {'meta_key': 'some_metadata'}),
+           ('another name', {})]
+
+def create_scalar_map(applies_to_matrix_dimension):
+    maps = [ci.Cifti2NamedMap(name, ci.Cifti2MetaData(meta)) for name, meta in scalars]
+    return ci.Cifti2MatrixIndicesMap(applies_to_matrix_dimension, 'CIFTI_INDEX_TYPE_SCALARS',
+                                     maps=maps)
+
+def check_scalar_map(mapping):
+    assert_equal(mapping.indices_map_to_data_type, 'CIFTI_INDEX_TYPE_SCALARS')
+    assert_equal(len(list(mapping.named_maps)), 2)
+
+    for expected, named_map in zip(scalars, mapping.named_maps):
+        assert_equal(named_map.map_name, expected[0])
+        if len(expected[1]) == 0:
+            assert_equal(named_map.metadata, None)
+        else:
+            assert_equal(named_map.metadata, expected[1])
+
+
+labels = [('first_name', {'meta_key': 'some_metadata'}, {0: ('label0', (0.1, 0.3, 0.2, 0.5)),
+                                                         1: ('new_label', (0.5, 0.3, 0.1, 0.4))}),
+          ('another name', {}, {0: ('???', (0, 0, 0, 0)),
+                                1: ('great region', (0.4, 0.1, 0.23, 0.15))})]
+
+
+def create_label_map(applies_to_matrix_dimension):
+    maps = []
+    for name, meta, label in labels:
+        label_table = ci.Cifti2LabelTable()
+        for key, (tag, rgba) in label.items():
+            label_table[key] = ci.Cifti2Label(key, tag, *rgba)
+        maps.append(ci.Cifti2NamedMap(name, ci.Cifti2MetaData(meta), label_table))
+    return ci.Cifti2MatrixIndicesMap(applies_to_matrix_dimension, 'CIFTI_INDEX_TYPE_LABELS',
+                                     maps=maps)
+
+def check_label_map(mapping):
+    assert_equal(mapping.indices_map_to_data_type, 'CIFTI_INDEX_TYPE_LABELS')
+    assert_equal(len(list(mapping.named_maps)), 2)
+
+    for expected, named_map in zip(scalars, mapping.named_maps):
+        assert_equal(named_map.map_name, expected[0])
+        if len(expected[1]) == 0:
+            assert_equal(named_map.metadata, None)
+        else:
+            assert_equal(named_map.metadata, expected[1])
+
+
+def create_series_map(applies_to_matrix_dimension):
+    return ci.Cifti2MatrixIndicesMap(applies_to_matrix_dimension, 'CIFTI_INDEX_TYPE_SERIES',
+                                     number_of_series_points=13, series_exponent=-3, series_start=18.2,
+                                     series_step=10.5, series_unit='SECOND')
+
+
+def check_series_map(mapping):
+    assert_equal(mapping.indices_map_to_data_type, 'CIFTI_INDEX_TYPE_SERIES')
+    assert_equal(mapping.number_of_series_points, 13)
+    assert_equal(mapping.series_exponent, -3)
+    assert_equal(mapping.series_start, 18.2)
+    assert_equal(mapping.series_step, 10.5)
+    assert_equal(mapping.series_unit, 'SECOND')
+
+
+def test_dtseries():
+    series_map = create_series_map((0, ))
+    geometry_map = create_geometry_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(series_map)
+    matrix.append(geometry_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(13, 9)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.dtseries.nii')
+        img2 = ci.load('test.dtseries.nii')
+        assert_true((img2.get_data() == data).all())
+        check_series_map(img2.header.matrix.get_index_map(0))
+        check_geometry_map(img2.header.matrix.get_index_map(1))
+
+
+def test_dscalar():
+    scalar_map = create_scalar_map((0, ))
+    geometry_map = create_geometry_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(scalar_map)
+    matrix.append(geometry_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(2, 9)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.dscalar.nii')
+        img2 = ci.load('test.dscalar.nii')
+        assert_true((img2.get_data() == data).all())
+        check_scalar_map(img2.header.matrix.get_index_map(0))
+        check_geometry_map(img2.header.matrix.get_index_map(1))
+
+
+def test_dlabel():
+    label_map = create_label_map((0, ))
+    geometry_map = create_geometry_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(label_map)
+    matrix.append(geometry_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(2, 9)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.dlabel.nii')
+        img2 = ci.load('test.dlabel.nii')
+        assert_true((img2.get_data() == data).all())
+        check_label_map(img2.header.matrix.get_index_map(0))
+        check_geometry_map(img2.header.matrix.get_index_map(1))
+
+
+def test_dconn():
+    mapping = create_geometry_map((0, 1))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(mapping)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(9, 9)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.dconn.nii')
+        img2 = ci.load('test.dconn.nii')
+        assert_true((img2.get_data() == data).all())
+        assert_equal(img2.header.matrix.get_index_map(0),
+                     img2.header.matrix.get_index_map(1))
+
+        check_geometry_map(img2.header.matrix.get_index_map(0))
+
+
+def test_ptseries():
+    series_map = create_series_map((0, ))
+    parcel_map = create_parcel_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(series_map)
+    matrix.append(parcel_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(13, 3)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.ptseries.nii')
+        img2 = ci.load('test.ptseries.nii')
+        assert_true((img2.get_data() == data).all())
+        check_series_map(img2.header.matrix.get_index_map(0))
+        check_parcel_map(img2.header.matrix.get_index_map(1))
+
+
+def test_pscalar():
+    scalar_map = create_scalar_map((0, ))
+    parcel_map = create_parcel_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(scalar_map)
+    matrix.append(parcel_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(2, 3)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.pscalar.nii')
+        img2 = ci.load('test.pscalar.nii')
+        assert_true((img2.get_data() == data).all())
+        check_scalar_map(img2.header.matrix.get_index_map(0))
+        check_parcel_map(img2.header.matrix.get_index_map(1))
+
+
+def test_pdconn():
+    geometry_map = create_geometry_map((0, ))
+    parcel_map = create_parcel_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(geometry_map)
+    matrix.append(parcel_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(2, 3)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.pdconn.nii')
+        img2 = ci.load('test.pdconn.nii')
+        assert_true((img2.get_data() == data).all())
+        check_geometry_map(img2.header.matrix.get_index_map(0))
+        check_parcel_map(img2.header.matrix.get_index_map(1))
+
+
+def test_dpconn():
+    parcel_map = create_parcel_map((0, ))
+    geometry_map = create_geometry_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(parcel_map)
+    matrix.append(geometry_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(2, 3)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.dpconn.nii')
+        img2 = ci.load('test.dpconn.nii')
+        assert_true((img2.get_data() == data).all())
+        check_parcel_map(img2.header.matrix.get_index_map(0))
+        check_geometry_map(img2.header.matrix.get_index_map(1))
+
+
+def test_plabel():
+    label_map = create_label_map((0, ))
+    parcel_map = create_parcel_map((1, ))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(label_map)
+    matrix.append(parcel_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(2, 3)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.plabel.nii')
+        img2 = ci.load('test.plabel.nii')
+        assert_true((img2.get_data() == data).all())
+        check_label_map(img2.header.matrix.get_index_map(0))
+        check_parcel_map(img2.header.matrix.get_index_map(1))
+
+
+def test_pconn():
+    mapping = create_parcel_map((0, 1))
+    matrix = ci.Cifti2Matrix()
+    matrix.append(mapping)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(3, 3)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.pconn.nii')
+        img2 = ci.load('test.pconn.nii')
+        assert_true((img2.get_data() == data).all())
+        assert_equal(img2.header.matrix.get_index_map(0),
+                     img2.header.matrix.get_index_map(1))
+
+        check_parcel_map(img2.header.matrix.get_index_map(0))
+
+
+def test_pconnseries():
+    parcel_map = create_parcel_map((0, 1))
+    series_map = create_series_map((2, ))
+
+    matrix = ci.Cifti2Matrix()
+    matrix.append(parcel_map)
+    matrix.append(series_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(3, 3, 13)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.pconnseries.nii')
+        img2 = ci.load('test.pconnseries.nii')
+        assert_true((img2.get_data() == data).all())
+        assert_equal(img2.header.matrix.get_index_map(0),
+                     img2.header.matrix.get_index_map(1))
+
+        check_parcel_map(img2.header.matrix.get_index_map(0))
+        check_series_map(img2.header.matrix.get_index_map(2))
+
+
+def test_pconnscalar():
+    parcel_map = create_parcel_map((0, 1))
+    scalar_map = create_scalar_map((2, ))
+
+    matrix = ci.Cifti2Matrix()
+    matrix.append(parcel_map)
+    matrix.append(scalar_map)
+    hdr = ci.Cifti2Header(matrix)
+    data = np.random.randn(3, 3, 13)
+    img = ci.Cifti2Image(data, hdr)
+
+    with InTemporaryDirectory():
+        ci.save(img, 'test.pconnscalar.nii')
+        img2 = ci.load('test.pconnscalar.nii')
+        assert_true((img2.get_data() == data).all())
+        assert_equal(img2.header.matrix.get_index_map(0),
+                     img2.header.matrix.get_index_map(1))
+
+        check_parcel_map(img2.header.matrix.get_index_map(0))
+        check_scalar_map(img2.header.matrix.get_index_map(2))


### PR DESCRIPTION
These tests check that:
1. we correctly read in the geometry (i.e. BrainModel), parcels, scalars, time series, and labels from the test data
2. we can generate a whole variety of CIFTI files from scratch (and correctly read them back in). The only files in the CIFTI documentation that I do not test are the fiber CIFTI files, because they are just a specialization of the dense scalar files.

I also included two minor bug fixes. I hope this helps to get your amazing piece of code finally accepted into nibabel...